### PR TITLE
#151 토론방 필터링 기능 구현

### DIFF
--- a/backend/src/main/java/todoktodok/backend/discussion/application/dto/response/DiscussionResponse.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/dto/response/DiscussionResponse.java
@@ -8,10 +8,10 @@ import todoktodok.backend.note.application.dto.response.MyNoteResponse;
 
 public record DiscussionResponse(
         Long discussionId,
-        BookResponse bookResponse,
-        MemberResponse memberResponse,
+        BookResponse book,
+        MemberResponse member,
         LocalDateTime createdAt,
-        MyNoteResponse noteResponse,
+        MyNoteResponse note,
         String discussionTitle,
         String discussionOpinion
 ) {
@@ -21,7 +21,7 @@ public record DiscussionResponse(
                 new BookResponse(discussion.getBook()),
                 new MemberResponse(discussion.getMember()),
                 discussion.getCreatedAt(),
-                new MyNoteResponse(discussion.getNote()),
+                discussion.getNote() != null ? new MyNoteResponse(discussion.getNote()) : null,
                 discussion.getTitle(),
                 discussion.getContent()
         );

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
@@ -45,17 +45,20 @@ public class DiscussionQueryService {
             final String keyword,
             final DiscussionFilterType type
     ) {
-        Member member = findMember(memberId);
+        final Member member = findMember(memberId);
+
         if (keyword == null || keyword.isBlank()) {
             if (type.isTypeMine()) {
                 return getMyDiscussions(member);
             }
             return getDiscussions(memberId);
         }
+
         if (type.isTypeMine()) {
             return getMyDiscussionsByKeyword(keyword, member);
         }
-        return getDiscussionsByKeyword(keyword, type);
+
+        return getDiscussionsByKeyword(keyword);
     }
 
     private void validateMember(final Long memberId) {
@@ -91,8 +94,7 @@ public class DiscussionQueryService {
     }
 
     private List<DiscussionResponse> getDiscussionsByKeyword(
-            final String keyword,
-            final DiscussionFilterType type
+            final String keyword
     ) {
         return discussionRepository.searchByKeyword(keyword).stream()
                 .map(DiscussionResponse::new)

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import todoktodok.backend.discussion.application.dto.response.DiscussionResponse;
 import todoktodok.backend.discussion.domain.Discussion;
+import todoktodok.backend.discussion.domain.DiscussionFilterType;
 import todoktodok.backend.discussion.domain.repository.DiscussionRepository;
+import todoktodok.backend.member.domain.Member;
 import todoktodok.backend.member.domain.repository.MemberRepository;
 
 @Service
@@ -38,6 +40,24 @@ public class DiscussionQueryService {
         return new DiscussionResponse(discussion);
     }
 
+    public List<DiscussionResponse> getDiscussionsByKeywordAndType(
+            final Long memberId,
+            final String keyword,
+            final DiscussionFilterType type
+    ) {
+        Member member = findMember(memberId);
+        if (keyword == null || keyword.isBlank()) {
+            if (type.isTypeMine()) {
+                return getMyDiscussions(member);
+            }
+            return getDiscussions(memberId);
+        }
+        if (type.isTypeMine()) {
+            return getMyDiscussionsByKeyword(keyword, member);
+        }
+        return getDiscussionsByKeyword(keyword, type);
+    }
+
     private void validateMember(final Long memberId) {
         if (!memberRepository.existsById(memberId)) {
             throw new NoSuchElementException("해당 회원을 찾을 수 없습니다");
@@ -47,5 +67,35 @@ public class DiscussionQueryService {
     private Discussion findDiscussion(final Long discussionId) {
         return discussionRepository.findById(discussionId)
                 .orElseThrow(() -> new NoSuchElementException("해당 토론방을 찾을 수 없습니다"));
+    }
+
+    private Member findMember(final Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NoSuchElementException("해당하는 회원을 찾을 수 없습니다"));
+    }
+
+    private List<DiscussionResponse> getMyDiscussions(final Member member) {
+        return discussionRepository.findDiscussionsByMember(member).stream()
+                .map(DiscussionResponse::new)
+                .toList();
+    }
+
+    private List<DiscussionResponse> getMyDiscussionsByKeyword(
+            final String keyword,
+            final Member member
+    ) {
+        return discussionRepository.searchByKeywordAndMember(keyword, member).stream()
+                .filter(discussion -> discussion.isOwnedBy(member))
+                .map(DiscussionResponse::new)
+                .toList();
+    }
+
+    private List<DiscussionResponse> getDiscussionsByKeyword(
+            final String keyword,
+            final DiscussionFilterType type
+    ) {
+        return discussionRepository.searchByKeyword(keyword).stream()
+                .map(DiscussionResponse::new)
+                .toList();
     }
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/domain/DiscussionFilterType.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/domain/DiscussionFilterType.java
@@ -1,0 +1,12 @@
+package todoktodok.backend.discussion.domain;
+
+public enum DiscussionFilterType {
+
+    ALL,
+    MINE,
+    ;
+
+    public boolean isTypeMine() {
+        return this == MINE;
+    }
+}

--- a/backend/src/main/java/todoktodok/backend/discussion/domain/repository/DiscussionRepository.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/domain/repository/DiscussionRepository.java
@@ -11,8 +11,6 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
 
     List<Discussion> findDiscussionsByMember(Member member);
 
-    List<Discussion> findDiscussionsByTitleContainingIgnoreCaseOrBook_TitleIsContainingIgnoreCase(String title, String bookTitle);
-
     @Query("""
         select d from Discussion d
         where upper(d.title) like upper(concat('%', :keyword, '%'))

--- a/backend/src/main/java/todoktodok/backend/discussion/domain/repository/DiscussionRepository.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/domain/repository/DiscussionRepository.java
@@ -1,7 +1,48 @@
 package todoktodok.backend.discussion.domain.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import todoktodok.backend.discussion.domain.Discussion;
+import todoktodok.backend.member.domain.Member;
 
 public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
+
+    List<Discussion> findDiscussionsByMember(Member member);
+
+    List<Discussion> findDiscussionsByTitleContainingIgnoreCaseOrBook_TitleIsContainingIgnoreCase(String title, String bookTitle);
+
+    @Query("""
+        select d from Discussion d
+        where upper(d.title) like upper(concat('%', :keyword, '%'))
+        and d.deletedAt is null
+        union
+        select d from Discussion d
+        join d.book b
+        where upper(b.title) like upper(concat('%', :keyword, '%'))
+        and d.deletedAt is null
+        and b.deletedAt is null
+    """)
+    List<Discussion> searchByKeyword(
+            @Param("keyword") String keyword
+    );
+
+    @Query("""
+        select d from Discussion d
+        where upper(d.title) like upper(concat('%', :keyword, '%'))
+        and d.deletedAt is null
+        and d.member = :member
+        union
+        select d from Discussion d
+        join d.book b
+        where upper(b.title) like upper(concat('%', :keyword, '%'))
+        and d.deletedAt is null
+        and b.deletedAt is null
+        and d.member = :member
+    """)
+    List<Discussion> searchByKeywordAndMember(
+            @Param("keyword") String keyword,
+            @Param("member") Member member
+    );
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/presentation/DiscussionControllerV2.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/presentation/DiscussionControllerV2.java
@@ -5,16 +5,21 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import todoktodok.backend.discussion.application.dto.request.DiscussionRequestV2;
+import todoktodok.backend.discussion.application.dto.response.DiscussionResponse;
 import todoktodok.backend.discussion.application.service.command.DiscussionCommandService;
+import todoktodok.backend.discussion.application.service.query.DiscussionQueryService;
+import todoktodok.backend.discussion.domain.DiscussionFilterType;
 import todoktodok.backend.global.auth.Auth;
 import todoktodok.backend.global.auth.Role;
 import todoktodok.backend.global.resolver.LoginMember;
@@ -26,6 +31,7 @@ import todoktodok.backend.global.resolver.LoginMember;
 public class DiscussionControllerV2 {
 
     private final DiscussionCommandService discussionCommandService;
+    private final DiscussionQueryService discussionQueryService;
 
     @Operation(summary = "토론방 생성 API")
     @Auth(value = Role.USER)
@@ -40,4 +46,17 @@ public class DiscussionControllerV2 {
                 .location(URI.create("/api/v1/discussions/" + discussionId))
                 .build();
     }
+
+    @Operation(summary = "토론방 필터 API")
+    @Auth(value = Role.USER)
+    @GetMapping
+    public ResponseEntity<List<DiscussionResponse>> getDiscussionsByKeywordAndType(
+            @Parameter(hidden = true) @LoginMember final Long memberId,
+            @RequestParam(required = false) final String keyword,
+            @RequestParam final DiscussionFilterType type
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(discussionQueryService.getDiscussionsByKeywordAndType(memberId, keyword, type));
+    }
+
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/presentation/DiscussionControllerV2.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/presentation/DiscussionControllerV2.java
@@ -47,7 +47,7 @@ public class DiscussionControllerV2 {
                 .build();
     }
 
-    @Operation(summary = "토론방 필터 API")
+    @Operation(summary = "토론방 필터링 API")
     @Auth(value = Role.USER)
     @GetMapping
     public ResponseEntity<List<DiscussionResponse>> getDiscussionsByKeywordAndType(
@@ -58,5 +58,4 @@ public class DiscussionControllerV2 {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(discussionQueryService.getDiscussionsByKeywordAndType(memberId, keyword, type));
     }
-
 }

--- a/backend/src/main/java/todoktodok/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/todoktodok/backend/global/exception/GlobalExceptionHandler.java
@@ -7,8 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -33,9 +35,21 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> MethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+    public ResponseEntity<String> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         return ResponseEntity.badRequest()
                 .body(PREFIX + e.getBindingResult().getFieldErrors().getFirst().getDefaultMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<String> handleMethodArgumentTypeMismatchException(final MethodArgumentTypeMismatchException e) {
+        return ResponseEntity.badRequest()
+                .body(PREFIX + String.format("유효하지 않은 %s의 값입니다", e.getRequiredType().getName()));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<String> handleMissingServletRequestParameterException(final MissingServletRequestParameterException e) {
+        return ResponseEntity.badRequest()
+                .body(PREFIX + String.format("파라미터 %s가 존재하지 않습니다", e.getParameterName()));
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/backend/src/test/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryServiceTest.java
+++ b/backend/src/test/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryServiceTest.java
@@ -2,11 +2,14 @@ package todoktodok.backend.discussion.application.service.query;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import todoktodok.backend.DatabaseInitializer;
 import todoktodok.backend.InitializerTimer;
 import todoktodok.backend.discussion.application.dto.response.DiscussionResponse;
+import todoktodok.backend.discussion.domain.DiscussionFilterType;
 
 @ActiveProfiles("test")
 @Transactional
@@ -99,5 +103,125 @@ class DiscussionQueryServiceTest {
         assertThatThrownBy(() -> discussionQueryService.getDiscussion(memberId, discussionId))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("해당 토론방을 찾을 수 없습니다");
+    }
+
+    @Nested
+    @DisplayName("토론방 필터링 테스트")
+    class DiscussionFilterTest {
+
+        @BeforeEach
+        void setUp() {
+            databaseInitializer.setDefaultUserInfo();
+            databaseInitializer.setUserInfo(
+                    "user2@gmail.com", "user2", "", ""
+            );
+
+            databaseInitializer.setBookInfo(
+                    "오브젝트v1", "book1입니다", "book1Author", "book1Publisher", "1233", ""
+            );
+            databaseInitializer.setBookInfo(
+                    "book2", "book2입니다", "book2Author", "book2Publisher", "1234", ""
+            );
+
+            databaseInitializer.setDiscussionInfo(
+                    "user1의 book1 토론", "토론1입니다", 1L, 1L, null
+            );
+            databaseInitializer.setDiscussionInfo(
+                    "user1의 클린코드 토론", "토론1입니다", 1L, 2L, null
+            );
+            databaseInitializer.setDiscussionInfo(
+                    "user2의 클린코드 토론", "토론2입니다", 2L, 2L, null
+            );
+        }
+
+        @Test
+        @DisplayName("전체 토론방을 조회할 수 있다")
+        void getAllDiscussionsTest() {
+            // given - when
+            final List<DiscussionResponse> discussions = discussionQueryService.getDiscussionsByKeywordAndType(
+                    1L, null, DiscussionFilterType.ALL
+            );
+
+            // then
+            assertThat(discussions).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("전체 토론방을 대상으로 키워드로 조회할 수 있다")
+        void getAllDiscussionsByKeywordTest() {
+            // given - when
+            final List<DiscussionResponse> discussions = discussionQueryService.getDiscussionsByKeywordAndType(
+                    1L, "book2", DiscussionFilterType.ALL
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(discussions).hasSize(2),
+                    () -> assertThat(discussions.get(0).discussionId()).isEqualTo(2L),
+                    () -> assertThat(discussions.get(1).discussionId()).isEqualTo(3L)
+            );
+        }
+
+        @Test
+        @DisplayName("나의 토론방을 조회할 수 있다")
+        void getMyDiscussionsTest() {
+            // given - when
+            final List<DiscussionResponse> discussions = discussionQueryService.getDiscussionsByKeywordAndType(
+                    1L, null, DiscussionFilterType.MINE
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(discussions).hasSize(2),
+                    () -> assertThat(discussions.get(0).discussionId()).isEqualTo(1L),
+                    () -> assertThat(discussions.get(1).discussionId()).isEqualTo(2L)
+            );
+        }
+
+        @Test
+        @DisplayName("나의 토론방을 대상으로 키워드로 조회할 수 있다")
+        void getMyDiscussionsByKeywordTest() {
+            // given - when
+            final List<DiscussionResponse> discussions = discussionQueryService.getDiscussionsByKeywordAndType(
+                    1L, "클린코드", DiscussionFilterType.MINE
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(discussions).hasSize(1),
+                    () -> assertThat(discussions.get(0).discussionId()).isEqualTo(2L)
+            );
+        }
+
+        @Test
+        @DisplayName("키워드 조회 시 책 제목에 키워드가 포함되면 조회된다")
+        void getDiscussionsByBookTitleKeywordTest() {
+            // given - when
+            final List<DiscussionResponse> discussions = discussionQueryService.getDiscussionsByKeywordAndType(
+                    1L, "오브젝트", DiscussionFilterType.ALL
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(discussions).hasSize(1),
+                    () -> assertThat(discussions.get(0).discussionId()).isEqualTo(1L)
+            );
+        }
+
+        @Test
+        @DisplayName("키워드 조회 시 토론방 제목에 키워드가 포함되면 조회된다")
+        void getDiscussionsByDiscussionTitleKeywordTest() {
+            // given - when
+            final List<DiscussionResponse> discussions = discussionQueryService.getDiscussionsByKeywordAndType(
+                    1L, "클린코드", DiscussionFilterType.ALL
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(discussions).hasSize(2),
+                    () -> assertThat(discussions.get(0).discussionId()).isEqualTo(2L),
+                    () -> assertThat(discussions.get(1).discussionId()).isEqualTo(3L)
+            );
+        }
     }
 }

--- a/backend/src/test/java/todoktodok/backend/discussion/presentation/DiscussionControllerV2Test.java
+++ b/backend/src/test/java/todoktodok/backend/discussion/presentation/DiscussionControllerV2Test.java
@@ -14,7 +14,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import todoktodok.backend.DatabaseInitializer;
 import todoktodok.backend.InitializerTimer;
-import todoktodok.backend.discussion.application.dto.request.DiscussionRequest;
 import todoktodok.backend.discussion.application.dto.request.DiscussionRequestV2;
 import todoktodok.backend.member.presentation.fixture.MemberFixture;
 
@@ -58,5 +57,47 @@ public class DiscussionControllerV2Test {
                 .when().post("/api/v2/discussions")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    @DisplayName("토론방을 필터링한다")
+    void filterDiscussions() {
+        // given
+        databaseInitializer.setDefaultUserInfo();
+        databaseInitializer.setDefaultBookInfo();
+        databaseInitializer.setDiscussionInfo(
+                "오브젝트", "오브젝트 토론입니다", 1L, 1L, null
+        );
+
+        final String token = MemberFixture.login("user@gmail.com");
+
+        // when - then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header("Authorization", token)
+                .when().get("/api/v2/discussions?keyword=오브젝트&type=ALL")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("토론방을 필터링할 때 type을 명시하지 않으면 예외가 발생한다")
+    void fail_filterDiscussions() {
+        // given
+        databaseInitializer.setDefaultUserInfo();
+        databaseInitializer.setDefaultBookInfo();
+        databaseInitializer.setDiscussionInfo(
+                "오브젝트", "오브젝트 토론입니다", 1L, 1L, null
+        );
+
+        final String token = MemberFixture.login("user@gmail.com");
+
+        // when - then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header("Authorization", token)
+                .when().get("/api/v2/discussions?keyword=오브젝트")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }


### PR DESCRIPTION
## 작업 내용 요약

<!-- 주요 개발 작업 내용을 간단히 서술해주세요 -->
<!-- 공동 작업이라면, 각자의 담당 영역을 함께 표기해주세요 -->

- close #151 
- 토론방 필터링 API 및 테스트 추가
- RequestParam에는 2가지가 있습니다. 자세한 건 아래를 참고해서 코드를 이해해주세요!
<h3>RequestParam</h3>
<ul>
<li><code>type</code> : <code>필수</code> 필터링할 대상을 선택합니다.</li>
<li><code>keyword</code> : <code>선택</code> 필터링할 키워드를 선택합니다.</li>
</ul>
<p>✅ <code>type</code>에 들어갈 수 있는 String입니다. Enum이므로 value 값들 중 하나를 넣어야 합니다. (대문자까지!)</p>

value | 의미
-- | --
ALL | 전체 토론방 대상 조회
MINE | 내 토론방 대상 조회


<p>ex. 전체 토론방 대상으로 &lt;오브젝트&gt; 키워드 검색 : <code>/api/v2/discussions?keyword=오브젝트&amp;type=ALL</code></p>
<p>ex. 내 토론방 대상으로 &lt;오브젝트&gt; 키워드 검색 : <code>/api/v2/discussions?keyword=오브젝트&amp;type=MINE</code></p>
<p>ex. 내 토론방 전체 조회 : <code>/api/v2/discussions?type=MINE</code></p>
<!-- notionvc: d0df8f4c-ae73-4e59-beed-450937b2cfc4 -->

## 피드백받을 점
- 쿼리가 복잡한데, 최대한 지피티랑 면담하면서 개선해보았어요. (조회가 복잡하므로 쿼리문으로 필터링을 모두 끝냈습니다) 더좋은 쿼리문이 있다면 제안 ㄱㄱ!!
- `전체 조회` / `전체 대상 검색` / `내토론방 조회` / `내토론방 대상 검색` 기능을 모두 하나의 URI로 하고, 상세 구분을 **쿼리 파라미터**로 구현했어요. 이는 필터링 조건이 각각 달라도 <토론방>이라는 자원은 같기 때문입니다. 이에 대한 다른 생각이 있다면 편하게 제시해주세욤~

---

## 리뷰/머지 희망 기한 (선택)

<!-- 해당 PR이 언제까지 리뷰되길 바라는지 작성해주세요 -->

- 내일 오전 안에! 

---

<!-- 안드로이드 전용 추가 템플릿
## 셀프 체크리스트
- [ ] 프로그램이 정상적으로 작동하는가?
- [ ] 모든 테스트가 통과하는가?
- [ ] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [ ] 코딩 스타일 가이드를 준수하였는가?
- [ ] IDE 코드 자동 정렬을 적용하였는가?
- [ ] 린트 검사를 통과하였는가?

## 스크린샷

---

## 테스트 방법

---

-->

## 셀프 체크리스트
- [x] 프로그램이 정상적으로 작동하는가?
- [x] 모든 테스트가 통과하는가?
- [x] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [x] 코딩 스타일 가이드를 준수하였는가?
- [x] IDE 코드 자동 정렬을 적용하였는가?


## 리뷰어 셀프 체크리스트

> 리뷰 시 복사해서 사용해주세요!

```
- [ ]  리뷰어의 로컬에서 정상적으로 동작함을 확인했나요?
- [ ]  필요한 테스트가 모두 작성되어있음을 확인했나요?
- [ ]  테스트가 모두 통과함을 확인했나요?
- [ ]  성공, 경계값, 예외 등 가능한 시나리오를 모두 확인했나요?
- [ ]  리뷰 시 Pn 룰을 적용했나요?
```

</details>

<br/>
<details>
<summary> ⛳️ Pn 그라운드 룰 </summary>
<br>
  
### P1: 꼭 반영해주세요 (Request changes)
리뷰어는 PR의 내용이 서비스에 중대한 오류를 발생할 수 있는 가능성을 잠재하고 있는 등 중대한 코드 수정이 반드시 필요하다고 판단되는 경우, P1 태그를 통해 리뷰 요청자에게 수정을 요청합니다. 리뷰 요청자는 p1 태그에 대해 리뷰어의 요청을 반영하거나, 반영할 수 없는 합리적인 의견을 통해 리뷰어를 설득할 수 있어야 합니다.

### P2: 적극적으로 고려해주세요 (Request changes)
작성자는 P2에 대해 수용하거나 만약 수용할 수 없는 상황이라면 적합한 의견을 들어 토론할 것을 권장합니다.

### P3: 웬만하면 반영해 주세요 (Comment)
작성자는 P3에 대해 수용하거나 만약 수용할 수 없는 상황이라면 반영할 수 없는 이유를 들어 설명하거나 다음에 반영할 계획을 명시적으로(JIRA 티켓 등으로) 표현할 것을 권장합니다. Request changes 가 아닌 Comment 와 함께 사용됩니다.

### P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
작성자는 P4에 대해서는 아무런 의견을 달지 않고 무시해도 괜찮습니다. 해당 의견을 반영하는 게 좋을지 고민해 보는 정도면 충분합니다.

### P5: 그냥 사소한 의견입니다 (Approve)
작성자는 P5에 대해 아무런 의견을 달지 않고 무시해도 괜찮습니다.

</details>


<br/>
<details>
<summary> 📖 효과적인 코드 리뷰를 위한 제안 </summary>

## 1. 작업 목표 설정

### 목표 명확화
- 이슈 티켓 발행 시 이슈의 목표를 명확히 설정한다
- 큰 작업은 여러 개의 작은 티켓으로 분할하여 진행한다
- **PR은 최대 500 Line 제한**
- 주요 변경사항이나 새로운 패턴 도입 시 **반드시 사전에 논의**한다

## 2. 마감 기한 설정
- 리뷰 및 반영 기간이 길어질수록 PR의 크기는 커진다
- 리뷰에 대한 부담을 줄이기 위해 **피드백 마감기한을 팀과 설정**
  - **리뷰 완료 기준 24시간 이내**

## 3. 리뷰어의 자세와 원칙

### 3.1 기본 원칙
- 피드백은 **코드, 프로세스, 사양만**을 대상으로 한다
- 리뷰이와 리뷰어의 인격과는 **분리**되어야 한다
- 언어 폭력이나 비난이 섞인 지적은 리뷰가 아니다
- **시간에 쫓겨 리뷰의 품질을 낮추지 말자**

### 3.2 리뷰어의 자세
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것. 새로 감정이 상하지 않도록 노력이 필요
- **적절한 시간 분배**: 리뷰어가 감당할 수 있는 양의 리뷰를 나누고, 피드백 마감기한을 지키자
- **우선순위를 정해 피드백이 필요한 부분만 간단히 리뷰를 주고받는다**

### 3.3 리뷰 의견 제시 방법

#### 건설적 피드백
- **긍정적 표현 사용**
  - ❌ "이 코드는 잘못되었다"
  - ✅ "이 부분을 다음과 같이 개선할 수 있을 것 같습니다"

#### 구체적인 제안
- ❌ "성능이 안 좋다"
- ✅ "A 방법 대신 B를 사용하면 가독성이 향상될 것 같습니다"

#### 리뷰는 토론과 같다
- 토론을 하되, 리뷰를 넘길 때도 의견과 함께 리뷰어가 납득할 수 있는 이유와 근거(자료 등)를 충분히 제시

### 3.4 적절한 시간 분배
- 리뷰를 위한 리뷰는 리뷰 품질의 저하을 초래한다. 피드백 할 부분이 없다면 **칭찬을 남기자**
- 사람은 누구나 실수한다
- **리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요**
- 실수를 지적받았을 때 **방어적이 되지 않는다**

---

## 효과적인 코드 리뷰를 위한 마인드셋
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것
- **사람은 누구나 실수한다**: 리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요
- **칭찬도 좋은 코드 리뷰이다**: 특별히 남길 의견이 없다면 칭찬을 해보자

### 리뷰를 위한 리뷰 자제
- 리뷰를 위한 리뷰는 자제하자. 리뷰를 위한 리뷰는 지적을 초래한다

---
</details>
