### PR TITLE
#349 토론방 조회 시, 전체 댓글 수가 댓글 및 대댓글의 합계로 조회되도록 수정

### DIFF
--- a/backend/src/main/java/todoktodok/backend/comment/application/service/query/CommentLikeCountDto.java
+++ b/backend/src/main/java/todoktodok/backend/comment/application/service/query/CommentLikeCountDto.java
@@ -11,7 +11,7 @@ public record CommentLikeCountDto(
     ) {
         this(
                 commentId,
-                likeCount.intValue()
+                Math.toIntExact(likeCount)
         );
     }
 }

--- a/backend/src/main/java/todoktodok/backend/comment/application/service/query/CommentReplyCountDto.java
+++ b/backend/src/main/java/todoktodok/backend/comment/application/service/query/CommentReplyCountDto.java
@@ -5,6 +5,6 @@ public record CommentReplyCountDto(
         int replyCount
 ) {
     public CommentReplyCountDto(final Long commentId, final Long replyCount) {
-        this(commentId, replyCount.intValue());
+        this(commentId, Math.toIntExact(replyCount));
     }
 }

--- a/backend/src/main/java/todoktodok/backend/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/todoktodok/backend/comment/domain/repository/CommentRepository.java
@@ -15,9 +15,14 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     boolean existsCommentsByDiscussion(final Discussion discussion);
 
     @Query("""
-        SELECT new todoktodok.backend.discussion.application.service.query.DiscussionCommentCountDto(d.id, COUNT(c))
+        SELECT new todoktodok.backend.discussion.application.service.query.DiscussionCommentCountDto(
+            d.id,
+            COUNT(DISTINCT c.id),
+            COUNT(DISTINCT r.id)
+        )
         FROM Discussion d
-        LEFT JOIN Comment c ON c.discussion = d
+        LEFT JOIN Comment c ON c.discussion = d AND c.deletedAt IS NULL
+        LEFT JOIN Reply r ON r.comment = c AND r.deletedAt IS NULL
         WHERE d.id IN :discussionIds
         GROUP BY d.id
     """)

--- a/backend/src/main/java/todoktodok/backend/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/todoktodok/backend/comment/domain/repository/CommentRepository.java
@@ -21,8 +21,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             COUNT(DISTINCT r.id)
         )
         FROM Discussion d
-        LEFT JOIN Comment c ON c.discussion = d AND c.deletedAt IS NULL
-        LEFT JOIN Reply r ON r.comment = c AND r.deletedAt IS NULL
+        LEFT JOIN Comment c ON c.discussion = d
+        LEFT JOIN Reply r ON r.comment = c
         WHERE d.id IN :discussionIds
         GROUP BY d.id
     """)

--- a/backend/src/main/java/todoktodok/backend/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/todoktodok/backend/comment/domain/repository/CommentRepository.java
@@ -33,6 +33,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         FROM Comment c
         WHERE c.discussion.id = :discussionId
     """)
-    Long findCommentCountsByDiscussionId(@Param("discussionId") final Long discussionId);
-
+    Long countCommentsByDiscussionId(@Param("discussionId") final Long discussionId);
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionCommentCountDto.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionCommentCountDto.java
@@ -12,8 +12,8 @@ public record DiscussionCommentCountDto(
     ) {
         this(
                 discussionId,
-                commentCount.intValue(),
-                replyCount.intValue()
+                Math.toIntExact(commentCount),
+                Math.toIntExact(replyCount)
         );
     }
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionCommentCountDto.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionCommentCountDto.java
@@ -2,15 +2,18 @@ package todoktodok.backend.discussion.application.service.query;
 
 public record DiscussionCommentCountDto(
         Long discussionId,
-        int commentCount
+        int commentCount,
+        int replyCount
 ) {
     public DiscussionCommentCountDto(
             final Long discussionId,
-            final Long commentCount
+            final Long commentCount,
+            final Long replyCount
     ) {
         this(
                 discussionId,
-                commentCount.intValue()
+                commentCount.intValue(),
+                replyCount.intValue()
         );
     }
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionLikeCountDto.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionLikeCountDto.java
@@ -10,7 +10,7 @@ public record DiscussionLikeCountDto(
     ) {
         this(
                 discussionId,
-                likeCount.intValue()
+                Math.toIntExact(likeCount)
         );
     }
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
@@ -13,6 +13,7 @@ import todoktodok.backend.discussion.domain.repository.DiscussionLikeRepository;
 import todoktodok.backend.discussion.domain.repository.DiscussionRepository;
 import todoktodok.backend.member.domain.Member;
 import todoktodok.backend.member.domain.repository.MemberRepository;
+import todoktodok.backend.reply.domain.repository.ReplyRepository;
 
 @Service
 @Transactional(readOnly = true)
@@ -23,6 +24,7 @@ public class DiscussionQueryService {
     private final DiscussionLikeRepository discussionLikeRepository;
     private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
+    private final ReplyRepository replyRepository;
 
     public DiscussionResponse getDiscussion(
             final Long memberId,
@@ -32,7 +34,9 @@ public class DiscussionQueryService {
         final Discussion discussion = findDiscussion(discussionId);
 
         final int likeCount = Math.toIntExact(discussionLikeRepository.findLikeCountsByDiscussionId(discussionId));
-        final int commentCount = Math.toIntExact(commentRepository.findCommentCountsByDiscussionId(discussionId));
+        final int commentCount = Math.toIntExact(
+                commentRepository.countCommentsByDiscussionId(discussionId) + replyRepository.countRepliesByDiscussionId(discussionId)
+        );
         final boolean isLiked = discussionLikeRepository.existsByMemberAndDiscussion(member, discussion);
 
         return new DiscussionResponse(
@@ -128,7 +132,8 @@ public class DiscussionQueryService {
                 discussionIds);
         final List<DiscussionCommentCountDto> commentCountsById = commentRepository.findCommentCountsByDiscussionIds(
                 discussionIds);
-        final List<Long> likedDiscussionIds = discussionLikeRepository.findLikedDiscussionIdsByMember(member, discussionIds);
+        final List<Long> likedDiscussionIds = discussionLikeRepository.findLikedDiscussionIdsByMember(member,
+                discussionIds);
 
         return discussions.stream()
                 .map(discussion -> new DiscussionResponse(

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
@@ -2,7 +2,6 @@ package todoktodok.backend.discussion.application.service.query;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -148,7 +147,7 @@ public class DiscussionQueryService {
         return commentCountsById.stream()
                 .filter(count -> discussion.isSameId(count.discussionId()))
                 .findFirst()
-                .map(DiscussionCommentCountDto::commentCount)
+                .map(dto -> dto.commentCount() + dto.replyCount())
                 .orElseThrow(() -> new IllegalStateException("토론방의 댓글 수를 찾을 수 없습니다"));
     }
 

--- a/backend/src/main/java/todoktodok/backend/reply/application/service/query/ReplyLikeCountDto.java
+++ b/backend/src/main/java/todoktodok/backend/reply/application/service/query/ReplyLikeCountDto.java
@@ -11,7 +11,7 @@ public record ReplyLikeCountDto(
     ) {
         this(
                 replyId,
-                likeCount.intValue()
+                Math.toIntExact(likeCount)
         );
     }
 }

--- a/backend/src/main/java/todoktodok/backend/reply/domain/repository/ReplyRepository.java
+++ b/backend/src/main/java/todoktodok/backend/reply/domain/repository/ReplyRepository.java
@@ -24,4 +24,14 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
     List<Reply> findRepliesByComment(final Comment comment);
 
     boolean existsByComment(final Comment comment);
+
+    @Query("""
+        SELECT COUNT(r)
+        FROM Reply r
+        JOIN r.comment c
+        WHERE c.discussion.id = :discussionId
+        AND r.deletedAt IS NULL
+        AND c.deletedAt IS NULL
+    """)
+    Long countRepliesByDiscussionId(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/todoktodok/backend/reply/domain/repository/ReplyRepository.java
+++ b/backend/src/main/java/todoktodok/backend/reply/domain/repository/ReplyRepository.java
@@ -30,8 +30,6 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
         FROM Reply r
         JOIN r.comment c
         WHERE c.discussion.id = :discussionId
-        AND r.deletedAt IS NULL
-        AND c.deletedAt IS NULL
     """)
     Long countRepliesByDiscussionId(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/test/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryServiceTest.java
+++ b/backend/src/test/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryServiceTest.java
@@ -354,6 +354,29 @@ class DiscussionQueryServiceTest {
         }
 
         @Test
+        @DisplayName("전체 토론방을 조회할 때, 조회되는 댓글 수는 댓글과 대댓글 수의 합이다")
+        void getAllDiscussions_totalCommentCountTest() {
+            // given
+            databaseInitializer.setDefaultUserInfo();
+            databaseInitializer.setDefaultDiscussionInfo();
+
+            final Long memberId = 1L;
+            final Long discussionId = 1L;
+            databaseInitializer.setCommentInfo("댓글1", memberId, discussionId);
+
+            final Long commentId = 1L;
+            databaseInitializer.setReplyInfo("대댓글1", memberId, commentId);
+
+            // when
+            final List<DiscussionResponse> discussions = discussionQueryService.getDiscussionsByKeywordAndType(
+                    memberId, null, DiscussionFilterType.ALL
+            );
+
+            // then
+            assertThat(discussions.get(0).commentCount()).isEqualTo(2);
+        }
+
+        @Test
         @DisplayName("토론방 필터링 조회 시 나의 좋아요 여부를 반환한다")
         void getDiscussions_isLikedTest() {
             // given

--- a/backend/src/test/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryServiceTest.java
+++ b/backend/src/test/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryServiceTest.java
@@ -132,6 +132,35 @@ class DiscussionQueryServiceTest {
     }
 
     @Test
+    @DisplayName("특정 토론방의 전체 댓글 수는 댓글 수와 대댓글 수의 합이다")
+    void getDiscussion_TotalCommentCountTest() {
+        // given
+        databaseInitializer.setDefaultUserInfo();
+        databaseInitializer.setDefaultBookInfo();
+
+        final Long memberId = 1L;
+        final Long bookId = 1L;
+
+        databaseInitializer.setDiscussionInfo(
+                "클린코드에 대해 논의해볼까요",
+                "클린코드만세",
+                memberId,
+                bookId
+        );
+
+        final Long discussionId = 1L;
+
+        databaseInitializer.setCommentInfo("댓글1", memberId, discussionId);
+        databaseInitializer.setReplyInfo("대댓글1", memberId, 1L);
+
+        // when
+        final DiscussionResponse discussion = discussionQueryService.getDiscussion(memberId, discussionId);
+
+        // then
+        assertThat(discussion.commentCount()).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("토론방 단일 조회 시 내가 좋아요를 생성한 글인지 확인한다")
     void getDiscussion_isLikedTest_true() {
         // given
@@ -362,9 +391,11 @@ class DiscussionQueryServiceTest {
 
             final Long memberId = 1L;
             final Long discussionId = 1L;
+
             databaseInitializer.setCommentInfo("댓글1", memberId, discussionId);
 
             final Long commentId = 1L;
+
             databaseInitializer.setReplyInfo("대댓글1", memberId, commentId);
 
             // when


### PR DESCRIPTION
## 작업 내용 요약

<!-- 주요 개발 작업 내용을 간단히 서술해주세요 -->
<!-- 공동 작업이라면, 각자의 담당 영역을 함께 표기해주세요 -->

- 전체 토론방 조회 시, 각 토론방의 전체 댓글 수가 댓글 및 대댓글의 합계로 조회되도록 수정
- 단일 토론방 조회 시, 전체 댓글 수가 댓글 및 대댓글의 합계로 조회되도록 수정

쿼리 위주로 리뷰해주시면 감사드리겠습니다.

1. 기존 findCommentCountsByDiscussionIds 메서드의 쿼리에 Reply 테이블을 left join 해서 대댓글의 개수를 추가로 가져오도록 수정했습니다. 
count 함수를 통해 합계 자체를 가져오는 방식은 불가능한 것 같아서 Dto에 따로 담아오고 추후 DiscussionQueryService의 findCommentCount 메서드에서 stream을 돌 때, 합계를 구하도록 했습니다.

2. ReplyRepository에 countRepliesByDiscussionId 메서드를 추가했습니다. 
DiscussionQueryService의 getDiscussion을 호출했을 때, 내부에서 댓글 및 대댓글 수를 더하도록 수정했습니다.


---

## 리뷰/머지 희망 기한 (선택)

<!-- 해당 PR이 언제까지 리뷰되길 바라는지 작성해주세요 -->

- 오늘까지

---

<!-- 안드로이드 전용 추가 템플릿
## 셀프 체크리스트
- [ ] 프로그램이 정상적으로 작동하는가?
- [ ] 모든 테스트가 통과하는가?
- [ ] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [ ] 코딩 스타일 가이드를 준수하였는가?
- [ ] IDE 코드 자동 정렬을 적용하였는가?
- [ ] 린트 검사를 통과하였는가?

## 스크린샷

---

## 테스트 방법

---

-->

<!-- 백엔드 전용 추가 템플릿

## 셀프 체크리스트
- [ ] 프로그램이 정상적으로 작동하는가?
- [ ] 모든 테스트가 통과하는가?
- [ ] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [ ] 코딩 스타일 가이드를 준수하였는가?
- [ ] IDE 코드 자동 정렬을 적용하였는가?

-->

## 리뷰어 셀프 체크리스트

> 리뷰 시 복사해서 사용해주세요!

```
- [ ]  리뷰어의 로컬에서 정상적으로 동작함을 확인했나요?
- [ ]  필요한 테스트가 모두 작성되어있음을 확인했나요?
- [ ]  테스트가 모두 통과함을 확인했나요?
- [ ]  성공, 경계값, 예외 등 가능한 시나리오를 모두 확인했나요?
- [ ]  리뷰 시 Pn 룰을 적용했나요?
```

</details>

<br/>
<details>
<summary> ⛳️ Pn 그라운드 룰 </summary>
<br>
  
### P1: 꼭 반영해주세요 (Request changes)
리뷰어는 PR의 내용이 서비스에 중대한 오류를 발생할 수 있는 가능성을 잠재하고 있는 등 중대한 코드 수정이 반드시 필요하다고 판단되는 경우, P1 태그를 통해 리뷰 요청자에게 수정을 요청합니다. 리뷰 요청자는 p1 태그에 대해 리뷰어의 요청을 반영하거나, 반영할 수 없는 합리적인 의견을 통해 리뷰어를 설득할 수 있어야 합니다.

### P2: 적극적으로 고려해주세요 (Request changes)
작성자는 P2에 대해 수용하거나 만약 수용할 수 없는 상황이라면 적합한 의견을 들어 토론할 것을 권장합니다.

### P3: 웬만하면 반영해 주세요 (Comment)
작성자는 P3에 대해 수용하거나 만약 수용할 수 없는 상황이라면 반영할 수 없는 이유를 들어 설명하거나 다음에 반영할 계획을 명시적으로(JIRA 티켓 등으로) 표현할 것을 권장합니다. Request changes 가 아닌 Comment 와 함께 사용됩니다.

### P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
작성자는 P4에 대해서는 아무런 의견을 달지 않고 무시해도 괜찮습니다. 해당 의견을 반영하는 게 좋을지 고민해 보는 정도면 충분합니다.

### P5: 그냥 사소한 의견입니다 (Approve)
작성자는 P5에 대해 아무런 의견을 달지 않고 무시해도 괜찮습니다.

</details>


<br/>
<details>
<summary> 📖 효과적인 코드 리뷰를 위한 제안 </summary>

## 1. 작업 목표 설정

### 목표 명확화
- 이슈 티켓 발행 시 이슈의 목표를 명확히 설정한다
- 큰 작업은 여러 개의 작은 티켓으로 분할하여 진행한다
- **PR은 최대 500 Line 제한**
- 주요 변경사항이나 새로운 패턴 도입 시 **반드시 사전에 논의**한다

## 2. 마감 기한 설정
- 리뷰 및 반영 기간이 길어질수록 PR의 크기는 커진다
- 리뷰에 대한 부담을 줄이기 위해 **피드백 마감기한을 팀과 설정**
  - **리뷰 완료 기준 24시간 이내**

## 3. 리뷰어의 자세와 원칙

### 3.1 기본 원칙
- 피드백은 **코드, 프로세스, 사양만**을 대상으로 한다
- 리뷰이와 리뷰어의 인격과는 **분리**되어야 한다
- 언어 폭력이나 비난이 섞인 지적은 리뷰가 아니다
- **시간에 쫓겨 리뷰의 품질을 낮추지 말자**

### 3.2 리뷰어의 자세
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것. 새로 감정이 상하지 않도록 노력이 필요
- **적절한 시간 분배**: 리뷰어가 감당할 수 있는 양의 리뷰를 나누고, 피드백 마감기한을 지키자
- **우선순위를 정해 피드백이 필요한 부분만 간단히 리뷰를 주고받는다**

### 3.3 리뷰 의견 제시 방법

#### 건설적 피드백
- **긍정적 표현 사용**
  - ❌ "이 코드는 잘못되었다"
  - ✅ "이 부분을 다음과 같이 개선할 수 있을 것 같습니다"

#### 구체적인 제안
- ❌ "성능이 안 좋다"
- ✅ "A 방법 대신 B를 사용하면 가독성이 향상될 것 같습니다"

#### 리뷰는 토론과 같다
- 토론을 하되, 리뷰를 넘길 때도 의견과 함께 리뷰어가 납득할 수 있는 이유와 근거(자료 등)를 충분히 제시

### 3.4 적절한 시간 분배
- 리뷰를 위한 리뷰는 리뷰 품질의 저하을 초래한다. 피드백 할 부분이 없다면 **칭찬을 남기자**
- 사람은 누구나 실수한다
- **리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요**
- 실수를 지적받았을 때 **방어적이 되지 않는다**

---

## 효과적인 코드 리뷰를 위한 마인드셋
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것
- **사람은 누구나 실수한다**: 리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요
- **칭찬도 좋은 코드 리뷰이다**: 특별히 남길 의견이 없다면 칭찬을 해보자

### 리뷰를 위한 리뷰 자제
- 리뷰를 위한 리뷰는 자제하자. 리뷰를 위한 리뷰는 지적을 초래한다

---
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 토론 목록/상세의 댓글 수가 이제 대댓글을 포함해 총 개수로 표시됩니다.
- Bug Fixes
  - 삭제된 댓글/대댓글이 댓글 수에 포함되지 않도록 집계 방식을 수정했습니다.
- Tests
  - 단일 토론 및 목록 조회에서 댓글 수가 댓글+대댓글 합계로 정확히 표시되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->