### PR TITLE
#374 토론방 로깅 방식 개선

### DIFF
--- a/backend/src/main/java/todoktodok/backend/discussion/application/dto/request/DiscussionRequest.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/dto/request/DiscussionRequest.java
@@ -9,11 +9,11 @@ public record DiscussionRequest(
         Long bookId,
 
         @NotBlank(message = "토론방 제목을 입력해주세요")
-        @Size(min = 1, max = 50, message = "토론방 제목은 1자 이상, 50자 이하여야 합니다")
+        @Size(max = 50, message = "토론방 제목은 1자 이상, 50자 이하여야 합니다")
         String discussionTitle,
 
         @NotBlank(message = "토론방 내용을 입력해주세요")
-        @Size(min = 1, max = 2500, message = "토론방 내용은 1자 이상, 2500자 이하여야 합니다")
+        @Size(max = 2500, message = "토론방 내용은 1자 이상, 2500자 이하여야 합니다")
         String discussionOpinion
 ) {
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/application/dto/request/DiscussionUpdateRequest.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/dto/request/DiscussionUpdateRequest.java
@@ -5,11 +5,11 @@ import jakarta.validation.constraints.Size;
 
 public record DiscussionUpdateRequest(
         @NotBlank(message = "토론방 제목을 입력해주세요")
-        @Size(min = 1, max = 50, message = "토론방 제목은 1자 이상, 50자 이하여야 합니다")
+        @Size(max = 50, message = "토론방 제목은 1자 이상, 50자 이하여야 합니다")
         String discussionTitle,
 
         @NotBlank(message = "토론방 내용을 입력해주세요")
-        @Size(min = 1, max = 2500, message = "토론방 내용은 1자 이상, 2500자 이하여야 합니다")
+        @Size(max = 2500, message = "토론방 내용은 1자 이상, 2500자 이하여야 합니다")
         String discussionOpinion
 ) {
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/command/DiscussionCommandService.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/command/DiscussionCommandService.java
@@ -122,7 +122,7 @@ public class DiscussionCommandService {
     private void validateHasComment(final Discussion discussion) {
         if (commentRepository.existsCommentsByDiscussion(discussion)) {
             throw new IllegalArgumentException(
-                    String.format("댓글이 존재하는 토론방은 삭제할 수 없습니다: discussionId=%d", discussion.getId())
+                    String.format("댓글이 존재하는 토론방은 삭제할 수 없습니다: discussionId= %s", discussion.getId())
             );
         }
     }
@@ -130,21 +130,21 @@ public class DiscussionCommandService {
     private Member findMember(final Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new NoSuchElementException(
-                        String.format("해당 회원을 찾을 수 없습니다: memberId=%d", memberId))
+                        String.format("해당 회원을 찾을 수 없습니다: memberId= %s", memberId))
                 );
     }
 
     private Book findBook(final Long bookId) {
         return bookRepository.findById(bookId)
                 .orElseThrow(() -> new NoSuchElementException(
-                        String.format("해당 도서를 찾을 수 없습니다: bookId=%d", bookId))
+                        String.format("해당 도서를 찾을 수 없습니다: bookId= %s", bookId))
                 );
     }
 
     private Discussion findDiscussion(final Long discussionId) {
         return discussionRepository.findById(discussionId)
                 .orElseThrow(() -> new NoSuchElementException(
-                        String.format("해당 토론방을 찾을 수 없습니다: discussionId=%d", discussionId))
+                        String.format("해당 토론방을 찾을 수 없습니다: discussionId= %s", discussionId))
                 );
     }
 
@@ -155,7 +155,7 @@ public class DiscussionCommandService {
         if (!discussion.isOwnedBy(member)) {
             throw new IllegalArgumentException(
                     String.format(
-                            "자기 자신의 토론방만 수정/삭제 가능합니다: discussionId=%d, memberId=%d",
+                            "자기 자신의 토론방만 수정/삭제 가능합니다: discussionId= %s, memberId= %s",
                             discussion.getId(),
                             member.getId())
             );
@@ -169,7 +169,7 @@ public class DiscussionCommandService {
         if (discussionReportRepository.existsByDiscussionAndMember(discussion, member)) {
             throw new IllegalArgumentException(
                     String.format(
-                            "이미 신고한 토론방입니다: discussionId=%d, memberId=%d",
+                            "이미 신고한 토론방입니다: discussionId= %s, memberId= %s",
                             discussion.getId(),
                             member.getId()
                     )
@@ -183,7 +183,7 @@ public class DiscussionCommandService {
     ) {
         if (discussion.isOwnedBy(member)) {
             throw new IllegalArgumentException(
-                    String.format("자기 자신의 토론방을 신고할 수 없습니다: discussionId=%d, memberId=%d",
+                    String.format("자기 자신의 토론방을 신고할 수 없습니다: discussionId= %s, memberId= %s",
                             discussion.getId(),
                             member.getId()
                     )

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/command/DiscussionCommandService.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/command/DiscussionCommandService.java
@@ -121,23 +121,31 @@ public class DiscussionCommandService {
 
     private void validateHasComment(final Discussion discussion) {
         if (commentRepository.existsCommentsByDiscussion(discussion)) {
-            throw new IllegalArgumentException("댓글이 존재하는 토론방은 삭제할 수 없습니다");
+            throw new IllegalArgumentException(
+                    String.format("댓글이 존재하는 토론방은 삭제할 수 없습니다: discussionId=%d", discussion.getId())
+            );
         }
     }
 
     private Member findMember(final Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new NoSuchElementException("해당 회원을 찾을 수 없습니다"));
+                .orElseThrow(() -> new NoSuchElementException(
+                        String.format("해당 회원을 찾을 수 없습니다: memberId=%d", memberId))
+                );
     }
 
     private Book findBook(final Long bookId) {
         return bookRepository.findById(bookId)
-                .orElseThrow(() -> new NoSuchElementException("해당 도서를 찾을 수 없습니다"));
+                .orElseThrow(() -> new NoSuchElementException(
+                        String.format("해당 도서를 찾을 수 없습니다: bookId=%d", bookId))
+                );
     }
 
     private Discussion findDiscussion(final Long discussionId) {
         return discussionRepository.findById(discussionId)
-                .orElseThrow(() -> new NoSuchElementException("해당 토론방을 찾을 수 없습니다"));
+                .orElseThrow(() -> new NoSuchElementException(
+                        String.format("해당 토론방을 찾을 수 없습니다: discussionId=%d", discussionId))
+                );
     }
 
     private void validateDiscussionMember(
@@ -145,7 +153,12 @@ public class DiscussionCommandService {
             final Member member
     ) {
         if (!discussion.isOwnedBy(member)) {
-            throw new IllegalArgumentException("자기 자신의 토론방만 수정/삭제 가능합니다");
+            throw new IllegalArgumentException(
+                    String.format(
+                            "자기 자신의 토론방만 수정/삭제 가능합니다: discussionId=%d, memberId=%d",
+                            discussion.getId(),
+                            member.getId())
+            );
         }
     }
 
@@ -154,7 +167,13 @@ public class DiscussionCommandService {
             final Member member
     ) {
         if (discussionReportRepository.existsByDiscussionAndMember(discussion, member)) {
-            throw new IllegalArgumentException("이미 신고한 토론방입니다");
+            throw new IllegalArgumentException(
+                    String.format(
+                            "이미 신고한 토론방입니다: discussionId=%d, memberId=%d",
+                            discussion.getId(),
+                            member.getId()
+                    )
+            );
         }
     }
 
@@ -163,7 +182,12 @@ public class DiscussionCommandService {
             final Member member
     ) {
         if (discussion.isOwnedBy(member)) {
-            throw new IllegalArgumentException("자기 자신의 토론방을 신고할 수 없습니다");
+            throw new IllegalArgumentException(
+                    String.format("자기 자신의 토론방을 신고할 수 없습니다: discussionId=%d, memberId=%d",
+                            discussion.getId(),
+                            member.getId()
+                    )
+            );
         }
     }
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
@@ -73,7 +73,7 @@ public class DiscussionQueryService {
     private Discussion findDiscussion(final Long discussionId) {
         return discussionRepository.findById(discussionId)
                 .orElseThrow(() -> new NoSuchElementException(
-                                String.format("해당 토론방을 찾을 수 없습니다: discussionId=%d", discussionId)
+                                String.format("해당 토론방을 찾을 수 없습니다: discussionId= %s", discussionId)
                         )
                 );
     }
@@ -81,7 +81,7 @@ public class DiscussionQueryService {
     private Member findMember(final Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new NoSuchElementException(
-                                String.format("해당 회원을 찾을 수 없습니다: memberId=%d", memberId)
+                                String.format("해당 회원을 찾을 수 없습니다: memberId= %s", memberId)
                         )
                 );
     }
@@ -161,7 +161,7 @@ public class DiscussionQueryService {
                 .findFirst()
                 .map(dto -> dto.commentCount() + dto.replyCount())
                 .orElseThrow(() -> new IllegalStateException(
-                                String.format("토론방의 댓글 수를 찾을 수 없습니다: discussionId=%d", discussion.getId())
+                                String.format("토론방의 댓글 수를 찾을 수 없습니다: discussionId= %s", discussion.getId())
                         )
                 );
     }
@@ -175,7 +175,7 @@ public class DiscussionQueryService {
                 .findFirst()
                 .map(DiscussionLikeCountDto::likeCount)
                 .orElseThrow(() -> new IllegalStateException(
-                        String.format("토론방의 좋아요 수를 찾을 수 없습니다: discussionId=%d", discussion.getId()))
+                        String.format("토론방의 좋아요 수를 찾을 수 없습니다: discussionId= %s", discussion.getId()))
                 );
     }
 

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
@@ -35,7 +35,8 @@ public class DiscussionQueryService {
 
         final int likeCount = Math.toIntExact(discussionLikeRepository.findLikeCountsByDiscussionId(discussionId));
         final int commentCount = Math.toIntExact(
-                commentRepository.countCommentsByDiscussionId(discussionId) + replyRepository.countRepliesByDiscussionId(discussionId)
+                commentRepository.countCommentsByDiscussionId(discussionId)
+                        + replyRepository.countRepliesByDiscussionId(discussionId)
         );
         final boolean isLiked = discussionLikeRepository.existsByMemberAndDiscussion(member, discussion);
 
@@ -71,12 +72,18 @@ public class DiscussionQueryService {
 
     private Discussion findDiscussion(final Long discussionId) {
         return discussionRepository.findById(discussionId)
-                .orElseThrow(() -> new NoSuchElementException("해당 토론방을 찾을 수 없습니다"));
+                .orElseThrow(() -> new NoSuchElementException(
+                                String.format("해당 토론방을 찾을 수 없습니다: discussionId=%d", discussionId)
+                        )
+                );
     }
 
     private Member findMember(final Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new NoSuchElementException("해당 회원을 찾을 수 없습니다"));
+                .orElseThrow(() -> new NoSuchElementException(
+                                String.format("해당 회원을 찾을 수 없습니다: memberId=%d", memberId)
+                        )
+                );
     }
 
     private List<DiscussionResponse> getDiscussionsByType(
@@ -153,7 +160,10 @@ public class DiscussionQueryService {
                 .filter(count -> discussion.isSameId(count.discussionId()))
                 .findFirst()
                 .map(dto -> dto.commentCount() + dto.replyCount())
-                .orElseThrow(() -> new IllegalStateException("토론방의 댓글 수를 찾을 수 없습니다"));
+                .orElseThrow(() -> new IllegalStateException(
+                                String.format("토론방의 댓글 수를 찾을 수 없습니다: discussionId=%d", discussion.getId())
+                        )
+                );
     }
 
     private int findLikeCount(
@@ -164,7 +174,9 @@ public class DiscussionQueryService {
                 .filter(count -> discussion.isSameId(count.discussionId()))
                 .findFirst()
                 .map(DiscussionLikeCountDto::likeCount)
-                .orElseThrow(() -> new IllegalStateException("토론방의 좋아요 수를 찾을 수 없습니다"));
+                .orElseThrow(() -> new IllegalStateException(
+                        String.format("토론방의 좋아요 수를 찾을 수 없습니다: discussionId=%d", discussion.getId()))
+                );
     }
 
     private boolean checkIsLikedByMe(

--- a/backend/src/main/java/todoktodok/backend/discussion/domain/Discussion.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/domain/Discussion.java
@@ -108,13 +108,21 @@ public class Discussion extends TimeStamp {
 
     private static void validateTitle(final String title) {
         if (title.isEmpty() || title.length() > TITLE_MAX_LENGTH) {
-            throw new IllegalArgumentException("토론방 제목은 1자 이상, 50자 이하여야 합니다");
+            throw new IllegalArgumentException(
+                    String.format("토론방 제목은 1자 이상, 50자 이하여야 합니다: %d자",
+                            title.length()
+                    )
+            );
         }
     }
 
     private static void validateContent(final String content) {
         if (content.isEmpty() || content.length() > CONTENT_MAX_LENGTH) {
-            throw new IllegalArgumentException("토론방 내용은 1자 이상, 2500자 이하여야 합니다");
+            throw new IllegalArgumentException(
+                    String.format("토론방 내용은 1자 이상, 2500자 이하여야 합니다: %d자",
+                            content.length()
+                            )
+            );
         }
     }
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/domain/Discussion.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/domain/Discussion.java
@@ -109,9 +109,7 @@ public class Discussion extends TimeStamp {
     private static void validateTitle(final String title) {
         if (title.isEmpty() || title.length() > TITLE_MAX_LENGTH) {
             throw new IllegalArgumentException(
-                    String.format("토론방 제목은 1자 이상, 50자 이하여야 합니다: %d자",
-                            title.length()
-                    )
+                    String.format("토론방 제목은 1자 이상, 50자 이하여야 합니다: %d자", title.length())
             );
         }
     }
@@ -119,9 +117,7 @@ public class Discussion extends TimeStamp {
     private static void validateContent(final String content) {
         if (content.isEmpty() || content.length() > CONTENT_MAX_LENGTH) {
             throw new IllegalArgumentException(
-                    String.format("토론방 내용은 1자 이상, 2500자 이하여야 합니다: %d자",
-                            content.length()
-                            )
+                    String.format("토론방 내용은 1자 이상, 2500자 이하여야 합니다: %d자", content.length())
             );
         }
     }

--- a/backend/src/main/java/todoktodok/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/todoktodok/backend/global/exception/GlobalExceptionHandler.java
@@ -85,6 +85,11 @@ public class GlobalExceptionHandler {
         }
 
         final String str = value.toString();
+
+        if (field.equals("discussionTitle") || field.equals("discussionOpinion")) {
+            return str.length() + "자";
+        }
+
         if (!field.equals("email")) {
             return str;
         }

--- a/backend/src/test/java/todoktodok/backend/discussion/application/service/command/DiscussionCommandServiceTest.java
+++ b/backend/src/test/java/todoktodok/backend/discussion/application/service/command/DiscussionCommandServiceTest.java
@@ -17,7 +17,6 @@ import todoktodok.backend.DatabaseInitializer;
 import todoktodok.backend.InitializerTimer;
 import todoktodok.backend.discussion.application.dto.request.DiscussionRequest;
 import todoktodok.backend.discussion.application.dto.request.DiscussionUpdateRequest;
-import todoktodok.backend.member.domain.repository.MemberRepository;
 
 @ActiveProfiles("test")
 @Transactional
@@ -55,7 +54,7 @@ class DiscussionCommandServiceTest {
         // when - then
         assertThatThrownBy(() -> discussionCommandService.createDiscussion(memberId, discussionRequest))
                 .isInstanceOf(NoSuchElementException.class)
-                .hasMessage("해당 회원을 찾을 수 없습니다");
+                .hasMessageContaining("해당 회원을 찾을 수 없습니다");
     }
 
     @Test
@@ -79,7 +78,7 @@ class DiscussionCommandServiceTest {
                 () -> discussionCommandService.createDiscussion(memberId, discussionRequest)
         )
                 .isInstanceOf(NoSuchElementException.class)
-                .hasMessage("해당 도서를 찾을 수 없습니다");
+                .hasMessageContaining("해당 도서를 찾을 수 없습니다");
     }
 
     @Test
@@ -105,7 +104,7 @@ class DiscussionCommandServiceTest {
         // when - then
         assertThatThrownBy(() -> discussionCommandService.updateDiscussion(memberId, discussionId, discussionUpdateRequest))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("자기 자신의 토론방만 수정/삭제 가능합니다");
+                .hasMessageContaining("자기 자신의 토론방만 수정/삭제 가능합니다");
     }
 
     @Test
@@ -124,7 +123,7 @@ class DiscussionCommandServiceTest {
         // when - then
         assertThatThrownBy(() -> discussionCommandService.deleteDiscussion(memberId, discussionId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("자기 자신의 토론방만 수정/삭제 가능합니다");
+                .hasMessageContaining("자기 자신의 토론방만 수정/삭제 가능합니다");
     }
 
     @Test
@@ -142,7 +141,7 @@ class DiscussionCommandServiceTest {
         // when - then
         assertThatThrownBy(() -> discussionCommandService.deleteDiscussion(memberId, discussionId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("댓글이 존재하는 토론방은 삭제할 수 없습니다");
+                .hasMessageContaining("댓글이 존재하는 토론방은 삭제할 수 없습니다");
     }
 
     @Test
@@ -163,7 +162,7 @@ class DiscussionCommandServiceTest {
         // then
         assertThatThrownBy(() -> discussionCommandService.report(memberId, discussionId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 신고한 토론방입니다");
+                .hasMessageContaining("이미 신고한 토론방입니다");
     }
 
     @Test
@@ -180,7 +179,7 @@ class DiscussionCommandServiceTest {
         // when - then
         assertThatThrownBy(() -> discussionCommandService.report(memberId, discussionId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("자기 자신의 토론방을 신고할 수 없습니다");
+                .hasMessageContaining("자기 자신의 토론방을 신고할 수 없습니다");
     }
 
     @Test

--- a/backend/src/test/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryServiceTest.java
+++ b/backend/src/test/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryServiceTest.java
@@ -98,7 +98,7 @@ class DiscussionQueryServiceTest {
         // when - then
         assertThatThrownBy(() -> discussionQueryService.getDiscussion(memberId, discussionId))
                 .isInstanceOf(NoSuchElementException.class)
-                .hasMessage("해당 토론방을 찾을 수 없습니다");
+                .hasMessageContaining("해당 토론방을 찾을 수 없습니다");
     }
 
     @Test

--- a/backend/src/test/java/todoktodok/backend/discussion/domain/DiscussionTest.java
+++ b/backend/src/test/java/todoktodok/backend/discussion/domain/DiscussionTest.java
@@ -39,7 +39,7 @@ class DiscussionTest {
                         .book(book)
                         .build()
         ).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("토론방 제목은 1자 이상, 50자 이하여야 합니다");
+                .hasMessageContaining("토론방 제목은 1자 이상, 50자 이하여야 합니다");
     }
 
     @Test
@@ -70,7 +70,7 @@ class DiscussionTest {
                         .book(book)
                         .build()
         ).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("토론방 제목은 1자 이상, 50자 이하여야 합니다");
+                .hasMessageContaining("토론방 제목은 1자 이상, 50자 이하여야 합니다");
     }
 
     @Test
@@ -101,7 +101,7 @@ class DiscussionTest {
                         .book(book)
                         .build()
         ).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("토론방 내용은 1자 이상, 2500자 이하여야 합니다");
+                .hasMessageContaining("토론방 내용은 1자 이상, 2500자 이하여야 합니다");
     }
 
     @Test
@@ -132,6 +132,6 @@ class DiscussionTest {
                         .book(book)
                         .build()
         ).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("토론방 내용은 1자 이상, 2500자 이하여야 합니다");
+                .hasMessageContaining("토론방 내용은 1자 이상, 2500자 이하여야 합니다");
     }
 }


### PR DESCRIPTION
## 작업 내용 요약

<!-- 주요 개발 작업 내용을 간단히 서술해주세요 -->
<!-- 공동 작업이라면, 각자의 담당 영역을 함께 표기해주세요 -->

-  Dicussion 관련 로깅 개선

### 변경 내용
DiscussionDto의 Validation 어노테이션 검증 시, 예외 로깅을 위해 maskEmailValue 메서드에 분기 처리를 추가했습니다.
기존에는
- email 필드에서 예외 발생 시: 이메일 마스킹 후 로깅
- 그 외 필드: 값을 그대로 로깅
방식을 사용했습니다.

그러나 토론방 본문 예외(예: 2,500자 초과) 발생 시, 매우 긴 문자열이 그대로 로그에 남는 문제가 발생할 수 있습니다.
또한, 토론방 제목과 본문 내용은 로그로 직접 남길 필요성이 낮다고 판단했습니다.

이에 따라,
- 제목/본문 필드의 경우: 제목 및 본문 value 대신 문자열 길이를 value 값으로 로깅
- email 필드: 기존처럼 마스킹 처리 후 로깅
- 나머지 필드: 기존 로직 유지

### 고려 사항
현재 GlobalExceptionHandler를 통해 통합 로깅을 처리하고 있어, 특정 필드별 분기 로직을 이 방식으로 처리했습니다.
다만, 추후 새로운 예외 필드가 추가될 경우 분기 로직이 계속 늘어날 수 있다는 점이 우려됩니다.


---

## 리뷰/머지 희망 기한 (선택)

<!-- 해당 PR이 언제까지 리뷰되길 바라는지 작성해주세요 -->

- 오늘까지

---

<!-- 안드로이드 전용 추가 템플릿
## 셀프 체크리스트
- [ ] 프로그램이 정상적으로 작동하는가?
- [ ] 모든 테스트가 통과하는가?
- [ ] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [ ] 코딩 스타일 가이드를 준수하였는가?
- [ ] IDE 코드 자동 정렬을 적용하였는가?
- [ ] 린트 검사를 통과하였는가?

## 스크린샷

---

## 테스트 방법

---

-->

<!-- 백엔드 전용 추가 템플릿

## 셀프 체크리스트
- [ ] 프로그램이 정상적으로 작동하는가?
- [ ] 모든 테스트가 통과하는가?
- [ ] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [ ] 코딩 스타일 가이드를 준수하였는가?
- [ ] IDE 코드 자동 정렬을 적용하였는가?

-->

## 리뷰어 셀프 체크리스트

> 리뷰 시 복사해서 사용해주세요!

```
- [ ]  리뷰어의 로컬에서 정상적으로 동작함을 확인했나요?
- [ ]  필요한 테스트가 모두 작성되어있음을 확인했나요?
- [ ]  테스트가 모두 통과함을 확인했나요?
- [ ]  성공, 경계값, 예외 등 가능한 시나리오를 모두 확인했나요?
- [ ]  리뷰 시 Pn 룰을 적용했나요?
```

</details>

<br/>
<details>
<summary> ⛳️ Pn 그라운드 룰 </summary>
<br>
  
### P1: 꼭 반영해주세요 (Request changes)
리뷰어는 PR의 내용이 서비스에 중대한 오류를 발생할 수 있는 가능성을 잠재하고 있는 등 중대한 코드 수정이 반드시 필요하다고 판단되는 경우, P1 태그를 통해 리뷰 요청자에게 수정을 요청합니다. 리뷰 요청자는 p1 태그에 대해 리뷰어의 요청을 반영하거나, 반영할 수 없는 합리적인 의견을 통해 리뷰어를 설득할 수 있어야 합니다.

### P2: 적극적으로 고려해주세요 (Request changes)
작성자는 P2에 대해 수용하거나 만약 수용할 수 없는 상황이라면 적합한 의견을 들어 토론할 것을 권장합니다.

### P3: 웬만하면 반영해 주세요 (Comment)
작성자는 P3에 대해 수용하거나 만약 수용할 수 없는 상황이라면 반영할 수 없는 이유를 들어 설명하거나 다음에 반영할 계획을 명시적으로(JIRA 티켓 등으로) 표현할 것을 권장합니다. Request changes 가 아닌 Comment 와 함께 사용됩니다.

### P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
작성자는 P4에 대해서는 아무런 의견을 달지 않고 무시해도 괜찮습니다. 해당 의견을 반영하는 게 좋을지 고민해 보는 정도면 충분합니다.

### P5: 그냥 사소한 의견입니다 (Approve)
작성자는 P5에 대해 아무런 의견을 달지 않고 무시해도 괜찮습니다.

</details>


<br/>
<details>
<summary> 📖 효과적인 코드 리뷰를 위한 제안 </summary>

## 1. 작업 목표 설정

### 목표 명확화
- 이슈 티켓 발행 시 이슈의 목표를 명확히 설정한다
- 큰 작업은 여러 개의 작은 티켓으로 분할하여 진행한다
- **PR은 최대 500 Line 제한**
- 주요 변경사항이나 새로운 패턴 도입 시 **반드시 사전에 논의**한다

## 2. 마감 기한 설정
- 리뷰 및 반영 기간이 길어질수록 PR의 크기는 커진다
- 리뷰에 대한 부담을 줄이기 위해 **피드백 마감기한을 팀과 설정**
  - **리뷰 완료 기준 24시간 이내**

## 3. 리뷰어의 자세와 원칙

### 3.1 기본 원칙
- 피드백은 **코드, 프로세스, 사양만**을 대상으로 한다
- 리뷰이와 리뷰어의 인격과는 **분리**되어야 한다
- 언어 폭력이나 비난이 섞인 지적은 리뷰가 아니다
- **시간에 쫓겨 리뷰의 품질을 낮추지 말자**

### 3.2 리뷰어의 자세
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것. 새로 감정이 상하지 않도록 노력이 필요
- **적절한 시간 분배**: 리뷰어가 감당할 수 있는 양의 리뷰를 나누고, 피드백 마감기한을 지키자
- **우선순위를 정해 피드백이 필요한 부분만 간단히 리뷰를 주고받는다**

### 3.3 리뷰 의견 제시 방법

#### 건설적 피드백
- **긍정적 표현 사용**
  - ❌ "이 코드는 잘못되었다"
  - ✅ "이 부분을 다음과 같이 개선할 수 있을 것 같습니다"

#### 구체적인 제안
- ❌ "성능이 안 좋다"
- ✅ "A 방법 대신 B를 사용하면 가독성이 향상될 것 같습니다"

#### 리뷰는 토론과 같다
- 토론을 하되, 리뷰를 넘길 때도 의견과 함께 리뷰어가 납득할 수 있는 이유와 근거(자료 등)를 충분히 제시

### 3.4 적절한 시간 분배
- 리뷰를 위한 리뷰는 리뷰 품질의 저하을 초래한다. 피드백 할 부분이 없다면 **칭찬을 남기자**
- 사람은 누구나 실수한다
- **리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요**
- 실수를 지적받았을 때 **방어적이 되지 않는다**

---

## 효과적인 코드 리뷰를 위한 마인드셋
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것
- **사람은 누구나 실수한다**: 리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요
- **칭찬도 좋은 코드 리뷰이다**: 특별히 남길 의견이 없다면 칭찬을 해보자

### 리뷰를 위한 리뷰 자제
- 리뷰를 위한 리뷰는 자제하자. 리뷰를 위한 리뷰는 지적을 초래한다

---
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 오류 메시지가 더 구체적으로 개선되어 관련 ID와 입력 길이 정보를 포함합니다.
  - 개인정보 보호 강화: 토론 제목/의견은 응답에서 내용 대신 길이(예: “5자”)만 표시됩니다.
- Tests
  - 오류 메시지 검증을 부분 일치 방식으로 완화하여 테스트 안정성을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->