### PR TITLE
#548 토론방 조회 후 토론방 정보 갱신 기능 추가

### DIFF
--- a/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/DiscussionDetailActivity.kt
+++ b/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/DiscussionDetailActivity.kt
@@ -198,7 +198,7 @@ class DiscussionDetailActivity : AppCompatActivity() {
                     progressBar.show()
                 } else {
                     progressBar.hide()
-                    val discussion = value.discussionItemUiState.discussion
+                    val discussion = value.discussion
                     tvBookTitle.text = discussion.book.title.extractSubtitle()
                     tvDiscussionTitle.text = discussion.discussionTitle
                     tvUserNickname.text = discussion.writer.nickname.value
@@ -211,8 +211,8 @@ class DiscussionDetailActivity : AppCompatActivity() {
                     tvLikeCount.text = discussion.likeCount.toString()
                     tvCommentCount.text = discussion.commentCount.toString()
                 }
+                setupPopUpDiscussionClick(value.isMyDiscussion)
             }
-            setupPopUpDiscussionClick(value.discussionItemUiState.isMyDiscussion)
         }
         viewModel.uiEvent.observe(this) { value ->
             handleEvent(value)
@@ -240,7 +240,7 @@ class DiscussionDetailActivity : AppCompatActivity() {
                 showSnackBar(R.string.all_report_discussion_success)
 
             is DiscussionDetailUiEvent.NavigateToDiscussionsWithResult -> {
-                moveToDiscussionsWithResult(event.mode, event.discussion)
+                moveToDiscussionsWithResult(event.isLiked, event.mode, event.discussion)
             }
         }
     }
@@ -252,6 +252,7 @@ class DiscussionDetailActivity : AppCompatActivity() {
     }
 
     private fun moveToDiscussionsWithResult(
+        isLiked: Boolean,
         mode: SerializationCreateDiscussionRoomMode?,
         discussion: SerializationDiscussion,
     ) {

--- a/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/DiscussionDetailActivity.kt
+++ b/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/DiscussionDetailActivity.kt
@@ -39,11 +39,10 @@ import com.team.todoktodok.presentation.view.discussiondetail.vm.DiscussionDetai
 import com.team.todoktodok.presentation.view.discussiondetail.vm.DiscussionDetailViewModel.Companion.KEY_DISCUSSION_ID
 import com.team.todoktodok.presentation.view.discussiondetail.vm.DiscussionDetailViewModel.Companion.KEY_MODE
 import com.team.todoktodok.presentation.view.discussiondetail.vm.DiscussionDetailViewModelFactory
-import com.team.todoktodok.presentation.view.discussions.BaseDiscussionsFragment.Companion.EXTRA_DELETE_DISCUSSION_ID
-import com.team.todoktodok.presentation.view.discussions.BaseDiscussionsFragment.Companion.EXTRA_MODIFIED_DISCUSSION
+import com.team.todoktodok.presentation.view.discussions.BaseDiscussionsFragment.Companion.EXTRA_DELETE_DISCUSSION
+import com.team.todoktodok.presentation.view.discussions.BaseDiscussionsFragment.Companion.EXTRA_WATCHED_DISCUSSION_ID
 import com.team.todoktodok.presentation.view.discussions.DiscussionsActivity
 import com.team.todoktodok.presentation.view.profile.ProfileActivity
-import com.team.todoktodok.presentation.view.serialization.SerializationDiscussion
 
 class DiscussionDetailActivity : AppCompatActivity() {
     private val viewModel by viewModels<DiscussionDetailViewModel> {
@@ -240,37 +239,39 @@ class DiscussionDetailActivity : AppCompatActivity() {
                 showSnackBar(R.string.all_report_discussion_success)
 
             is DiscussionDetailUiEvent.NavigateToDiscussionsWithResult -> {
-                moveToDiscussionsWithResult(event.isLiked, event.mode, event.discussion)
+                moveToDiscussionsWithResult(event.mode, event.discussionId)
             }
         }
     }
 
     private fun moveToDiscussionsWithDeletedDiscussionId(discussionId: Long) {
-        val resultIntent = Intent().putExtra(EXTRA_DELETE_DISCUSSION_ID, discussionId)
+        val resultIntent = Intent().putExtra(EXTRA_DELETE_DISCUSSION, discussionId)
         setResult(RESULT_OK, resultIntent)
         finish()
     }
 
     private fun moveToDiscussionsWithResult(
-        isLiked: Boolean,
         mode: SerializationCreateDiscussionRoomMode?,
-        discussion: SerializationDiscussion,
+        discussionId: Long,
     ) {
         when (mode) {
             is SerializationCreateDiscussionRoomMode.Create -> {
-                val intent = DiscussionsActivity.Intent(this)
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                val intent =
+                    DiscussionsActivity.Intent(this).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    }
                 startActivity(intent)
                 finish()
             }
 
-            is SerializationCreateDiscussionRoomMode.Edit -> {
-                val resultIntent = Intent().putExtra(EXTRA_MODIFIED_DISCUSSION, discussion)
+            else -> {
+                val resultIntent =
+                    Intent().apply {
+                        putExtra(EXTRA_WATCHED_DISCUSSION_ID, discussionId)
+                    }
                 setResult(RESULT_OK, resultIntent)
                 finish()
             }
-
-            else -> finish()
         }
     }
 

--- a/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/DiscussionDetailUiEvent.kt
+++ b/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/DiscussionDetailUiEvent.kt
@@ -2,7 +2,6 @@ package com.team.todoktodok.presentation.view.discussiondetail
 
 import com.team.domain.model.exception.TodokTodokExceptions
 import com.team.todoktodok.presentation.view.discussion.create.SerializationCreateDiscussionRoomMode
-import com.team.todoktodok.presentation.view.serialization.SerializationDiscussion
 
 sealed interface DiscussionDetailUiEvent {
     data class ShowComments(
@@ -23,7 +22,7 @@ sealed interface DiscussionDetailUiEvent {
 
     data class NavigateToDiscussionsWithResult(
         val mode: SerializationCreateDiscussionRoomMode?,
-        val discussion: SerializationDiscussion,
+        val discussionId: Long,
     ) : DiscussionDetailUiEvent
 
     data object ShowReportDiscussionSuccessMessage : DiscussionDetailUiEvent

--- a/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/DiscussionDetailUiState.kt
+++ b/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/DiscussionDetailUiState.kt
@@ -6,24 +6,4 @@ data class DiscussionDetailUiState(
     val discussion: Discussion,
     val isMyDiscussion: Boolean,
     val isLoading: Boolean = false,
-) {
-    companion object {
-        private val INIT_DISCUSSION =
-            Discussion(
-                id = -1L,
-                discussionTitle = "",
-                book = Book(-1L, "", "", ""),
-                writer = User(-1L, Nickname("동전"), ""),
-                createAt = LocalDateTime.of(2000, 1, 1, 1, 1),
-                discussionOpinion = "",
-                likeCount = 0,
-                commentCount = 0,
-                isLikedByMe = false,
-            )
-        val INIT_DISCUSSION_DETAIL_UI_STATE =
-            DiscussionDetailUiState(
-                discussionItemUiState = DiscussionItemUiState(INIT_DISCUSSION, false),
-                false,
-            )
-    }
-}
+)

--- a/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/DiscussionDetailUiState.kt
+++ b/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/DiscussionDetailUiState.kt
@@ -1,15 +1,11 @@
 package com.team.todoktodok.presentation.view.discussiondetail
 
-import com.team.domain.model.Book
 import com.team.domain.model.Discussion
-import com.team.domain.model.member.Nickname
-import com.team.domain.model.member.User
-import com.team.todoktodok.presentation.view.discussiondetail.model.DiscussionItemUiState
-import java.time.LocalDateTime
 
 data class DiscussionDetailUiState(
-    val discussionItemUiState: DiscussionItemUiState,
-    val isLoading: Boolean,
+    val discussion: Discussion,
+    val isMyDiscussion: Boolean,
+    val isLoading: Boolean = false,
 ) {
     companion object {
         private val INIT_DISCUSSION =

--- a/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/vm/DiscussionDetailViewModel.kt
+++ b/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussiondetail/vm/DiscussionDetailViewModel.kt
@@ -13,7 +13,6 @@ import com.team.todoktodok.presentation.core.event.SingleLiveData
 import com.team.todoktodok.presentation.view.discussion.create.SerializationCreateDiscussionRoomMode
 import com.team.todoktodok.presentation.view.discussiondetail.DiscussionDetailUiEvent
 import com.team.todoktodok.presentation.view.discussiondetail.DiscussionDetailUiState
-import com.team.todoktodok.presentation.view.serialization.toSerialization
 import kotlinx.coroutines.launch
 
 class DiscussionDetailViewModel(
@@ -41,12 +40,10 @@ class DiscussionDetailViewModel(
 
     fun onFinishEvent() {
         val currentState = _uiState.value ?: return
-        val isLiked = currentState.discussion.isLikedByMe
         onUiEvent(
             DiscussionDetailUiEvent.NavigateToDiscussionsWithResult(
                 mode,
-                isLiked,
-                currentState.discussion.toSerialization(),
+                currentState.discussion.id,
             ),
         )
     }

--- a/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussions/BaseDiscussionsFragment.kt
+++ b/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussions/BaseDiscussionsFragment.kt
@@ -6,11 +6,9 @@ import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.team.todoktodok.App
-import com.team.todoktodok.presentation.core.ext.getParcelableCompat
 import com.team.todoktodok.presentation.view.discussiondetail.DiscussionDetailActivity
 import com.team.todoktodok.presentation.view.discussions.vm.DiscussionsViewModel
 import com.team.todoktodok.presentation.view.discussions.vm.DiscussionsViewModelFactory
-import com.team.todoktodok.presentation.view.serialization.SerializationDiscussion
 
 abstract class BaseDiscussionsFragment(
     @LayoutRes layoutId: Int,
@@ -27,15 +25,29 @@ abstract class BaseDiscussionsFragment(
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
                 result.data?.let { data ->
-                    val deletedId =
-                        data.getLongExtra(EXTRA_DELETE_DISCUSSION_ID, DEFAULT_DELETE_DISCUSSION_ID)
-                    if (deletedId != DEFAULT_DELETE_DISCUSSION_ID) {
-                        viewModel.removeDiscussion(deletedId)
-                    }
+                    when {
+                        data.hasExtra(EXTRA_DELETE_DISCUSSION) -> {
+                            val deletedId =
+                                data.getLongExtra(
+                                    EXTRA_DELETE_DISCUSSION,
+                                    DEFAULT_DISCUSSION_ID,
+                                )
+                            if (deletedId != DEFAULT_DISCUSSION_ID) {
+                                viewModel.removeDiscussion(deletedId)
+                            }
+                        }
 
-                    data
-                        .getParcelableCompat<SerializationDiscussion>(EXTRA_MODIFIED_DISCUSSION)
-                        ?.let { viewModel.modifyDiscussion(it) }
+                        data.hasExtra(EXTRA_WATCHED_DISCUSSION_ID) -> {
+                            val discussionId =
+                                data.getLongExtra(
+                                    EXTRA_WATCHED_DISCUSSION_ID,
+                                    DEFAULT_DISCUSSION_ID,
+                                )
+                            if (discussionId != DEFAULT_DISCUSSION_ID) {
+                                viewModel.modifyDiscussion(discussionId)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -50,8 +62,8 @@ abstract class BaseDiscussionsFragment(
     }
 
     companion object {
-        const val EXTRA_DELETE_DISCUSSION_ID = "delete_discussion_id"
-        const val EXTRA_MODIFIED_DISCUSSION = "modified_discussion"
-        private const val DEFAULT_DELETE_DISCUSSION_ID = -1L
+        const val EXTRA_DELETE_DISCUSSION = "delete_discussion"
+        const val EXTRA_WATCHED_DISCUSSION_ID = "watched_discussion_id"
+        private const val DEFAULT_DISCUSSION_ID = -1L
     }
 }

--- a/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussions/vm/DiscussionsViewModel.kt
+++ b/android/TodokTodok/app/src/main/java/com/team/todoktodok/presentation/view/discussions/vm/DiscussionsViewModel.kt
@@ -15,7 +15,6 @@ import com.team.todoktodok.presentation.core.event.MutableSingleLiveData
 import com.team.todoktodok.presentation.core.event.SingleLiveData
 import com.team.todoktodok.presentation.view.discussions.DiscussionsUiEvent
 import com.team.todoktodok.presentation.view.discussions.DiscussionsUiState
-import com.team.todoktodok.presentation.view.serialization.SerializationDiscussion
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -161,10 +160,18 @@ class DiscussionsViewModel(
         _uiState.value = _uiState.value?.removeDiscussion(discussionId)
     }
 
-    fun modifyDiscussion(discussion: SerializationDiscussion) {
+    fun modifyDiscussion(discussionId: Long) {
+        viewModelScope.launch {
+            discussionRepository
+                .getDiscussion(discussionId)
+                .onSuccess {
+                    _uiState.value = _uiState.value?.modifyDiscussion(it)
+                }.onFailure {
+                    onUiEvent(DiscussionsUiEvent.ShowErrorMessage(it))
+                }
+        }
         onUiEvent(DiscussionsUiEvent.ClearSearchResult)
         clearSearchResult()
-        _uiState.value = _uiState.value?.modifyDiscussion(discussion.toDomain())
     }
 
     private fun withLoading(action: suspend () -> Unit) {


### PR DESCRIPTION
## 작업 내용 요약

<!-- 주요 개발 작업 내용을 간단히 서술해주세요 -->
<!-- 공동 작업이라면, 각자의 담당 영역을 함께 표기해주세요 -->

- 토론방 단일 조회후 토론 목록 화면으로 돌아올시 조회한 토론방 Id를 전달받아 
  단일 토론방 조회 API를 호출해 토론방 변경된 토론방 상태(좋아요, 댓글 수) 등을 갱신하도록 구현했습니다.

본래 좋아요 상태를 직접 ActivityResultLauncher로 받으려 했는데 조회수, 댓글 수 등의 요소들도 변경되어야하기에 
로직이 너무 복잡해질 것 같아 API 호출로 구현했습니다.

---

## 리뷰/머지 희망 기한 (선택)

<!-- 해당 PR이 언제까지 리뷰되길 바라는지 작성해주세요 -->

- 방학 중 셀프 머지 하겠습니다.

---

## 셀프 체크리스트
- [x] 프로그램이 정상적으로 작동하는가?
- [x] 모든 테스트가 통과하는가?
- [x] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [x] 코딩 스타일 가이드를 준수하였는가?
- [x] IDE 코드 자동 정렬을 적용하였는가?
- [x] 린트 검사를 통과하였는가?

## 스크린샷

https://github.com/user-attachments/assets/a6778f38-1136-4b9a-9c45-36a57f3832b0


---
<!-- 안드로이드 전용 추가 템플릿
## 테스트 방법

---

-->

<!-- 백엔드 전용 추가 템플릿

## 셀프 체크리스트
- [ ] 프로그램이 정상적으로 작동하는가?
- [ ] 모든 테스트가 통과하는가?
- [ ] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [ ] 코딩 스타일 가이드를 준수하였는가?
- [ ] IDE 코드 자동 정렬을 적용하였는가?

-->

## 리뷰어 셀프 체크리스트

> 리뷰 시 복사해서 사용해주세요!

```
- [ ]  리뷰어의 로컬에서 정상적으로 동작함을 확인했나요?
- [ ]  필요한 테스트가 모두 작성되어있음을 확인했나요?
- [ ]  테스트가 모두 통과함을 확인했나요?
- [ ]  성공, 경계값, 예외 등 가능한 시나리오를 모두 확인했나요?
- [ ]  리뷰 시 Pn 룰을 적용했나요?
```

</details>

<br/>
<details>
<summary> ⛳️ Pn 그라운드 룰 </summary>
<br>
  
### P1: 꼭 반영해주세요 (Request changes)
리뷰어는 PR의 내용이 서비스에 중대한 오류를 발생할 수 있는 가능성을 잠재하고 있는 등 중대한 코드 수정이 반드시 필요하다고 판단되는 경우, P1 태그를 통해 리뷰 요청자에게 수정을 요청합니다. 리뷰 요청자는 p1 태그에 대해 리뷰어의 요청을 반영하거나, 반영할 수 없는 합리적인 의견을 통해 리뷰어를 설득할 수 있어야 합니다.

### P2: 적극적으로 고려해주세요 (Request changes)
작성자는 P2에 대해 수용하거나 만약 수용할 수 없는 상황이라면 적합한 의견을 들어 토론할 것을 권장합니다.

### P3: 웬만하면 반영해 주세요 (Comment)
작성자는 P3에 대해 수용하거나 만약 수용할 수 없는 상황이라면 반영할 수 없는 이유를 들어 설명하거나 다음에 반영할 계획을 명시적으로(JIRA 티켓 등으로) 표현할 것을 권장합니다. Request changes 가 아닌 Comment 와 함께 사용됩니다.

### P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
작성자는 P4에 대해서는 아무런 의견을 달지 않고 무시해도 괜찮습니다. 해당 의견을 반영하는 게 좋을지 고민해 보는 정도면 충분합니다.

### P5: 그냥 사소한 의견입니다 (Approve)
작성자는 P5에 대해 아무런 의견을 달지 않고 무시해도 괜찮습니다.

</details>


<br/>
<details>
<summary> 📖 효과적인 코드 리뷰를 위한 제안 </summary>

## 1. 작업 목표 설정

### 목표 명확화
- 이슈 티켓 발행 시 이슈의 목표를 명확히 설정한다
- 큰 작업은 여러 개의 작은 티켓으로 분할하여 진행한다
- **PR은 최대 500 Line 제한**
- 주요 변경사항이나 새로운 패턴 도입 시 **반드시 사전에 논의**한다

## 2. 마감 기한 설정
- 리뷰 및 반영 기간이 길어질수록 PR의 크기는 커진다
- 리뷰에 대한 부담을 줄이기 위해 **피드백 마감기한을 팀과 설정**
  - **리뷰 완료 기준 24시간 이내**

## 3. 리뷰어의 자세와 원칙

### 3.1 기본 원칙
- 피드백은 **코드, 프로세스, 사양만**을 대상으로 한다
- 리뷰이와 리뷰어의 인격과는 **분리**되어야 한다
- 언어 폭력이나 비난이 섞인 지적은 리뷰가 아니다
- **시간에 쫓겨 리뷰의 품질을 낮추지 말자**

### 3.2 리뷰어의 자세
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것. 새로 감정이 상하지 않도록 노력이 필요
- **적절한 시간 분배**: 리뷰어가 감당할 수 있는 양의 리뷰를 나누고, 피드백 마감기한을 지키자
- **우선순위를 정해 피드백이 필요한 부분만 간단히 리뷰를 주고받는다**

### 3.3 리뷰 의견 제시 방법

#### 건설적 피드백
- **긍정적 표현 사용**
  - ❌ "이 코드는 잘못되었다"
  - ✅ "이 부분을 다음과 같이 개선할 수 있을 것 같습니다"

#### 구체적인 제안
- ❌ "성능이 안 좋다"
- ✅ "A 방법 대신 B를 사용하면 가독성이 향상될 것 같습니다"

#### 리뷰는 토론과 같다
- 토론을 하되, 리뷰를 넘길 때도 의견과 함께 리뷰어가 납득할 수 있는 이유와 근거(자료 등)를 충분히 제시

### 3.4 적절한 시간 분배
- 리뷰를 위한 리뷰는 리뷰 품질의 저하을 초래한다. 피드백 할 부분이 없다면 **칭찬을 남기자**
- 사람은 누구나 실수한다
- **리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요**
- 실수를 지적받았을 때 **방어적이 되지 않는다**

---

## 효과적인 코드 리뷰를 위한 마인드셋
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것
- **사람은 누구나 실수한다**: 리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요
- **칭찬도 좋은 코드 리뷰이다**: 특별히 남길 의견이 없다면 칭찬을 해보자

### 리뷰를 위한 리뷰 자제
- 리뷰를 위한 리뷰는 자제하자. 리뷰를 위한 리뷰는 지적을 초래한다

---
</details>
