### PR TITLE
#599 회원탈퇴 api 추가

### DIFF
--- a/backend/src/main/java/todoktodok/backend/member/application/service/command/MemberCommandService.java
+++ b/backend/src/main/java/todoktodok/backend/member/application/service/command/MemberCommandService.java
@@ -145,12 +145,7 @@ public class MemberCommandService {
     ) {
         final TokenInfo tokenInfo = jwtTokenProvider.getInfoByRefreshToken(refreshTokenRequest.refreshToken());
         Long refreshTokenMemberId = tokenInfo.id();
-        if (!refreshTokenMemberId.equals(accessTokenMemberId)) {
-            throw new IllegalArgumentException(
-                    String.format("리프레시 토큰과 액세스 토큰의 회원 정보가 일치하지 않습니다: accessToken memberId = %d, refreshToken memberId = %d",
-                            accessTokenMemberId, refreshTokenMemberId)
-            );
-        }
+        validateTokenMemberId(accessTokenMemberId, refreshTokenMemberId);
 
         final Member member = findMember(accessTokenMemberId);
         final RefreshToken refreshToken = findRefreshToken(refreshTokenRequest.refreshToken());
@@ -200,6 +195,18 @@ public class MemberCommandService {
         return memberRepository.findById(memberId)
                 .orElseThrow(
                         () -> new NoSuchElementException(String.format("해당 회원을 찾을 수 없습니다: memberId = %s", memberId)));
+    }
+
+    private static void validateTokenMemberId(
+            final Long accessTokenMemberId,
+            final Long refreshTokenMemberId
+    ) {
+        if (!refreshTokenMemberId.equals(accessTokenMemberId)) {
+            throw new IllegalArgumentException(
+                    String.format("리프레시 토큰과 액세스 토큰의 회원 정보가 일치하지 않습니다: accessToken memberId = %d, refreshToken memberId = %d",
+                            accessTokenMemberId, refreshTokenMemberId)
+            );
+        }
     }
 
     private void validateDuplicatedBlock(

--- a/backend/src/main/java/todoktodok/backend/member/application/service/command/MemberCommandService.java
+++ b/backend/src/main/java/todoktodok/backend/member/application/service/command/MemberCommandService.java
@@ -2,6 +2,7 @@ package todoktodok.backend.member.application.service.command;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
+
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/backend/src/main/java/todoktodok/backend/member/application/service/command/MemberCommandService.java
+++ b/backend/src/main/java/todoktodok/backend/member/application/service/command/MemberCommandService.java
@@ -106,6 +106,12 @@ public class MemberCommandService {
         return new ProfileUpdateResponse(member);
     }
 
+    public void deleteMember(final Long memberId) {
+        final Member member = findMember(memberId);
+
+        memberRepository.delete(member);
+    }
+
     public void deleteBlock(
             final Long memberId,
             final Long targetId

--- a/backend/src/main/java/todoktodok/backend/member/application/service/command/MemberCommandService.java
+++ b/backend/src/main/java/todoktodok/backend/member/application/service/command/MemberCommandService.java
@@ -144,7 +144,7 @@ public class MemberCommandService {
             final RefreshTokenRequest refreshTokenRequest
     ) {
         final TokenInfo tokenInfo = jwtTokenProvider.getInfoByRefreshToken(refreshTokenRequest.refreshToken());
-        Long refreshTokenMemberId = tokenInfo.id();
+        final Long refreshTokenMemberId = tokenInfo.id();
         validateTokenMemberId(accessTokenMemberId, refreshTokenMemberId);
 
         final Member member = findMember(accessTokenMemberId);

--- a/backend/src/main/java/todoktodok/backend/member/application/service/command/MemberCommandService.java
+++ b/backend/src/main/java/todoktodok/backend/member/application/service/command/MemberCommandService.java
@@ -139,10 +139,24 @@ public class MemberCommandService {
         return new ProfileUpdateResponse(member);
     }
 
-    public void deleteMember(final Long memberId) {
-        final Member member = findMember(memberId);
+    public void deleteMember(
+            final Long accessTokenMemberId,
+            final RefreshTokenRequest refreshTokenRequest
+    ) {
+        final TokenInfo tokenInfo = jwtTokenProvider.getInfoByRefreshToken(refreshTokenRequest.refreshToken());
+        Long refreshTokenMemberId = tokenInfo.id();
+        if (!refreshTokenMemberId.equals(accessTokenMemberId)) {
+            throw new IllegalArgumentException(
+                    String.format("리프레시 토큰과 액세스 토큰의 회원 정보가 일치하지 않습니다: accessToken memberId = %d, refreshToken memberId = %d",
+                            accessTokenMemberId, refreshTokenMemberId)
+            );
+        }
+
+        final Member member = findMember(accessTokenMemberId);
+        final RefreshToken refreshToken = findRefreshToken(refreshTokenRequest.refreshToken());
 
         memberRepository.delete(member);
+        refreshTokenRepository.delete(refreshToken);
     }
 
     public void deleteBlock(

--- a/backend/src/main/java/todoktodok/backend/member/presentation/MemberApiDocs.java
+++ b/backend/src/main/java/todoktodok/backend/member/presentation/MemberApiDocs.java
@@ -12,10 +12,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import todoktodok.backend.book.application.dto.response.BookResponse;
 import todoktodok.backend.discussion.application.dto.response.DiscussionResponse;
 import todoktodok.backend.global.exception.ErrorResponse;
+import todoktodok.backend.global.resolver.LoginMember;
 import todoktodok.backend.member.application.dto.request.LoginRequest;
 import todoktodok.backend.member.application.dto.request.MemberReportRequest;
 import todoktodok.backend.member.application.dto.request.ProfileUpdateRequest;
@@ -812,6 +814,86 @@ public interface MemberApiDocs {
                             examples = @ExampleObject(value = "{\"nickname\":\"수정된닉네임\", \"profileMessage\":\"수정된상태메시지\"}")
                     )
             ) final ProfileUpdateRequest profileUpdateRequest
+    );
+
+    @Operation(summary = "회원 탈퇴 API")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "회원 탈퇴 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "리프레시 토큰과 액세스 토큰의 회원 id 불일치",
+                                    value = "{\"code\":400, \"message\":\"[ERROR] 리프레시 토큰과 액세스 토큰의 회원 정보가 일치하지 않습니다\"}"
+                            )
+                    )),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "토큰 인증 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "JWT 오류",
+                                    value = "{\"code\":401, \"message\":\"[ERROR] 잘못된 로그인 시도입니다. 다시 시도해 주세요\"}"
+                            )
+                    )),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "액세스 토큰 만료 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "액세스 토큰 만료 오류",
+                                    value = "{\"code\":403, \"message\":\"[ERROR] 액세스 토큰이 만료되었습니다\"}"
+                            )
+                    )),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 리소스",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "회원 없음",
+                                            value = "{\"code\":404, \"message\":\"[ERROR] 해당 회원을 찾을 수 없습니다\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "리프레시 토큰 없음",
+                                            value = "{\"code\":404, \"message\":\"[ERROR] 해당 리프레시 토큰을 찾을 수 없습니다\"}"
+                                    )
+                            }
+                    )),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "서버 오류",
+                                    value = "{\"code\":500, \"message\":\"[ERROR] 서버 내부 오류가 발생했습니다\"}"
+                            )
+                    ))
+    })
+    ResponseEntity<Void> deleteMember(
+            @Parameter(hidden = true) final Long memberId,
+            @RequestBody(
+                    description = "리프레시 토큰",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = RefreshTokenRequest.class),
+                            examples = @ExampleObject(value = "{\"refreshToken\":\"eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZ21haWwuY29tIiwicm9sZSI6IlVTRVIiLCJleHAiOjE3 NTU2MTgxNjZ9._-0qTNmPyO1m6LnpEAwkGAB92Es0yBwxNBtmsq_VrGk\"}")
+                    )
+            ) final RefreshTokenRequest refreshTokenRequest
     );
 
     @Operation(summary = "차단 해제 API")

--- a/backend/src/main/java/todoktodok/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/todoktodok/backend/member/presentation/MemberController.java
@@ -161,7 +161,7 @@ public class MemberController implements MemberApiDocs {
     @DeleteMapping
     public ResponseEntity<Void> deleteMember(
             @LoginMember final Long memberId,
-            @RequestBody @Valid RefreshTokenRequest refreshTokenRequest
+            @RequestBody @Valid final RefreshTokenRequest refreshTokenRequest
     ) {
         memberCommandService.deleteMember(memberId, refreshTokenRequest);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)

--- a/backend/src/main/java/todoktodok/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/todoktodok/backend/member/presentation/MemberController.java
@@ -158,9 +158,10 @@ public class MemberController implements MemberApiDocs {
     @Auth(value = Role.USER)
     @DeleteMapping
     public ResponseEntity<Void> deleteMember(
-            @LoginMember final Long memberId
+            @LoginMember final Long memberId,
+            @RequestBody @Valid RefreshTokenRequest refreshTokenRequest
     ) {
-        memberCommandService.deleteMember(memberId);
+        memberCommandService.deleteMember(memberId, refreshTokenRequest);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();
     }

--- a/backend/src/main/java/todoktodok/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/todoktodok/backend/member/presentation/MemberController.java
@@ -20,10 +20,7 @@ import todoktodok.backend.global.auth.Auth;
 import todoktodok.backend.global.auth.Role;
 import todoktodok.backend.global.resolver.LoginMember;
 import todoktodok.backend.global.resolver.TempMember;
-import todoktodok.backend.member.application.dto.request.LoginRequest;
-import todoktodok.backend.member.application.dto.request.MemberReportRequest;
-import todoktodok.backend.member.application.dto.request.ProfileUpdateRequest;
-import todoktodok.backend.member.application.dto.request.SignupRequest;
+import todoktodok.backend.member.application.dto.request.*;
 import todoktodok.backend.member.application.dto.response.BlockMemberResponse;
 import todoktodok.backend.member.application.dto.response.ProfileResponse;
 import todoktodok.backend.member.application.dto.response.ProfileUpdateResponse;
@@ -128,6 +125,16 @@ public class MemberController implements MemberApiDocs {
     ) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberCommandService.updateProfile(memberId, profileUpdateRequest));
+    }
+
+    @Auth(value = Role.USER)
+    @DeleteMapping
+    public ResponseEntity<Void> deleteMember(
+            @LoginMember final Long memberId
+    ) {
+        memberCommandService.deleteMember(memberId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .build();
     }
 
     @Auth(value = Role.USER)

--- a/backend/src/main/java/todoktodok/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/todoktodok/backend/member/presentation/MemberController.java
@@ -1,7 +1,9 @@
 package todoktodok.backend.member.presentation;
 
 import jakarta.validation.Valid;
+
 import java.util.List;
+
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/backend/src/test/java/todoktodok/backend/member/application/service/command/MemberCommandServiceTest.java
+++ b/backend/src/test/java/todoktodok/backend/member/application/service/command/MemberCommandServiceTest.java
@@ -22,6 +22,7 @@ import todoktodok.backend.member.application.dto.request.LoginRequest;
 import todoktodok.backend.member.application.dto.request.ProfileUpdateRequest;
 import todoktodok.backend.member.application.dto.request.SignupRequest;
 import todoktodok.backend.member.application.dto.response.ProfileUpdateResponse;
+import todoktodok.backend.member.presentation.fixture.MemberFixture;
 
 @ActiveProfiles("test")
 @Transactional
@@ -242,6 +243,18 @@ class MemberCommandServiceTest {
 
         // then
         assertThat(memberCommandService.updateProfile(memberId, profileUpdateRequest)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원이 탈퇴하면 예외가 발생한다")
+    void deleteMemberTest_notFoundMember_fail() {
+        // given
+        final Long notExistsMemberId = 999L;
+
+        // when - then
+        assertThatThrownBy(() -> memberCommandService.deleteMember(notExistsMemberId))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessageContaining("해당 회원을 찾을 수 없습니다");
     }
 
     @Test

--- a/backend/src/test/java/todoktodok/backend/member/application/service/command/MemberCommandServiceTest.java
+++ b/backend/src/test/java/todoktodok/backend/member/application/service/command/MemberCommandServiceTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.jsonwebtoken.JwtException;
 import jakarta.persistence.EntityManager;
+
 import java.util.NoSuchElementException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -166,10 +168,10 @@ class MemberCommandServiceTest {
         databaseInitializer.setDefaultUserInfo();
 
         final String nickname = "user";
-        final SignupRequest signupRequest = new SignupRequest(nickname, "https://user.png",  "user22@gmail.com");
+        final SignupRequest signupRequest = new SignupRequest(nickname, "https://user.png", "user22@gmail.com");
 
         // when - then
-        assertThatThrownBy(() -> memberCommandService.signup(signupRequest,  "user22@gmail.com"))
+        assertThatThrownBy(() -> memberCommandService.signup(signupRequest, "user22@gmail.com"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("이미 존재하는 닉네임입니다");
     }

--- a/backend/src/test/java/todoktodok/backend/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/todoktodok/backend/member/presentation/MemberControllerTest.java
@@ -359,12 +359,13 @@ class MemberControllerTest {
         // given
         databaseInitializer.setUserInfo("user@gmail.com", "user", "https://image.png", "user");
 
-        final String accessToken = MemberFixture.getAccessToken("user@gmail.com");
+        final TokenResponse tokenResponse = MemberFixture.getAccessAndRefreshToken("user@gmail.com");
 
         // when - then
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header("Authorization", accessToken)
+                .header("Authorization", tokenResponse.accessToken())
+                .body(new RefreshTokenRequest(tokenResponse.refreshToken()))
                 .when().delete("/api/v1/members")
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value());

--- a/backend/src/test/java/todoktodok/backend/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/todoktodok/backend/member/presentation/MemberControllerTest.java
@@ -314,6 +314,23 @@ class MemberControllerTest {
     }
 
     @Test
+    @DisplayName("회원이 탈퇴한다")
+    void deleteMemberTest() {
+        // given
+        databaseInitializer.setUserInfo("user@gmail.com", "user", "https://image.png", "user");
+
+        final String token = MemberFixture.login("user@gmail.com");
+
+        // when - then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header("Authorization", token)
+                .when().delete("/api/v1/members")
+                .then().log().all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
     @DisplayName("차단한 회원 전체를 조회한다")
     void getBlockMembersTest() {
         // given


### PR DESCRIPTION
## 작업 내용 요약

<!-- 주요 개발 작업 내용을 간단히 서술해주세요 -->
<!-- 공동 작업이라면, 각자의 담당 영역을 함께 표기해주세요 -->

- close #599 
- 회원탈퇴 api 추가
- 회원 탈퇴 시 회원과 refreshToken을 삭제합니다.
- 리프레시토큰 api와 병합하면서 충돌이 있어서, files changed가 많습니다! 이번 변경 사항은 [여기](https://github.com/woowacourse-teams/2025-Todok-Todok/pull/602/files/9ad95b2a3dea093befaae5b9823c689e289afe35..a8eaeac9b215c581a738fd2d05aec93532db297b#diff-bf5f896eae886119f8b10082d4cd4a89bfe3c016ecfee21056bdc6af8dbb05f9)를 확인해주세요! 
  - 실제 커밋은 dba1407f258a0a0435a92e800d4b1e1d6f066ca3 부터인데, 여기부터 하면 conflict resolve한 커밋까지 포함돼서 너무 읽기가 힘들더라구요 ㅜㅜ 그래서 올려둔대로 3db0abe4a7e09f75edd1b224910bef6188aaea17 부터 읽으면 좋을듯!

- 이게 리프레시 토큰이 필요하다보니, MemberCommandServiceTest에서 예외 테스트를 만들 때 원하는 상황을 만들기가 어려워서 편법을 조-금씩 썼는데요.. ㅋㅋ 혹시 거슬리거나 더 좋은 방법을 추천한다면 말씀해주세용!
- 관련해서 정책을 확정해야 할 것 같아서 [노션 이슈](https://www.notion.so/sonjh/267ee47a09a38037b925d5a3450bf407?source=copy_link) 하나 올렸으니 함께 확인해주시면 감사하겠습니다!

---

## 리뷰/머지 희망 기한 (선택)

<!-- 해당 PR이 언제까지 리뷰되길 바라는지 작성해주세요 -->

- 오늘 안에!

---

<!-- 안드로이드 전용 추가 템플릿
## 셀프 체크리스트
- [ ] 프로그램이 정상적으로 작동하는가?
- [ ] 모든 테스트가 통과하는가?
- [ ] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [ ] 코딩 스타일 가이드를 준수하였는가?
- [ ] IDE 코드 자동 정렬을 적용하였는가?
- [ ] 린트 검사를 통과하였는가?

## 스크린샷

---

## 테스트 방법

---

-->


## 셀프 체크리스트
- [x] 프로그램이 정상적으로 작동하는가?
- [x] 모든 테스트가 통과하는가?
- [x] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [x] 코딩 스타일 가이드를 준수하였는가?
- [x] IDE 코드 자동 정렬을 적용하였는가?


## 리뷰어 셀프 체크리스트

> 리뷰 시 복사해서 사용해주세요!

```
- [ ]  리뷰어의 로컬에서 정상적으로 동작함을 확인했나요?
- [ ]  필요한 테스트가 모두 작성되어있음을 확인했나요?
- [ ]  테스트가 모두 통과함을 확인했나요?
- [ ]  성공, 경계값, 예외 등 가능한 시나리오를 모두 확인했나요?
- [ ]  리뷰 시 Pn 룰을 적용했나요?
```

</details>

<br/>
<details>
<summary> ⛳️ Pn 그라운드 룰 </summary>
<br>
  
### P1: 꼭 반영해주세요 (Request changes)
리뷰어는 PR의 내용이 서비스에 중대한 오류를 발생할 수 있는 가능성을 잠재하고 있는 등 중대한 코드 수정이 반드시 필요하다고 판단되는 경우, P1 태그를 통해 리뷰 요청자에게 수정을 요청합니다. 리뷰 요청자는 p1 태그에 대해 리뷰어의 요청을 반영하거나, 반영할 수 없는 합리적인 의견을 통해 리뷰어를 설득할 수 있어야 합니다.

### P2: 적극적으로 고려해주세요 (Request changes)
작성자는 P2에 대해 수용하거나 만약 수용할 수 없는 상황이라면 적합한 의견을 들어 토론할 것을 권장합니다.

### P3: 웬만하면 반영해 주세요 (Comment)
작성자는 P3에 대해 수용하거나 만약 수용할 수 없는 상황이라면 반영할 수 없는 이유를 들어 설명하거나 다음에 반영할 계획을 명시적으로(JIRA 티켓 등으로) 표현할 것을 권장합니다. Request changes 가 아닌 Comment 와 함께 사용됩니다.

### P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
작성자는 P4에 대해서는 아무런 의견을 달지 않고 무시해도 괜찮습니다. 해당 의견을 반영하는 게 좋을지 고민해 보는 정도면 충분합니다.

### P5: 그냥 사소한 의견입니다 (Approve)
작성자는 P5에 대해 아무런 의견을 달지 않고 무시해도 괜찮습니다.

</details>


<br/>
<details>
<summary> 📖 효과적인 코드 리뷰를 위한 제안 </summary>

## 1. 작업 목표 설정

### 목표 명확화
- 이슈 티켓 발행 시 이슈의 목표를 명확히 설정한다
- 큰 작업은 여러 개의 작은 티켓으로 분할하여 진행한다
- **PR은 최대 500 Line 제한**
- 주요 변경사항이나 새로운 패턴 도입 시 **반드시 사전에 논의**한다

## 2. 마감 기한 설정
- 리뷰 및 반영 기간이 길어질수록 PR의 크기는 커진다
- 리뷰에 대한 부담을 줄이기 위해 **피드백 마감기한을 팀과 설정**
  - **리뷰 완료 기준 24시간 이내**

## 3. 리뷰어의 자세와 원칙

### 3.1 기본 원칙
- 피드백은 **코드, 프로세스, 사양만**을 대상으로 한다
- 리뷰이와 리뷰어의 인격과는 **분리**되어야 한다
- 언어 폭력이나 비난이 섞인 지적은 리뷰가 아니다
- **시간에 쫓겨 리뷰의 품질을 낮추지 말자**

### 3.2 리뷰어의 자세
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것. 새로 감정이 상하지 않도록 노력이 필요
- **적절한 시간 분배**: 리뷰어가 감당할 수 있는 양의 리뷰를 나누고, 피드백 마감기한을 지키자
- **우선순위를 정해 피드백이 필요한 부분만 간단히 리뷰를 주고받는다**

### 3.3 리뷰 의견 제시 방법

#### 건설적 피드백
- **긍정적 표현 사용**
  - ❌ "이 코드는 잘못되었다"
  - ✅ "이 부분을 다음과 같이 개선할 수 있을 것 같습니다"

#### 구체적인 제안
- ❌ "성능이 안 좋다"
- ✅ "A 방법 대신 B를 사용하면 가독성이 향상될 것 같습니다"

#### 리뷰는 토론과 같다
- 토론을 하되, 리뷰를 넘길 때도 의견과 함께 리뷰어가 납득할 수 있는 이유와 근거(자료 등)를 충분히 제시

### 3.4 적절한 시간 분배
- 리뷰를 위한 리뷰는 리뷰 품질의 저하을 초래한다. 피드백 할 부분이 없다면 **칭찬을 남기자**
- 사람은 누구나 실수한다
- **리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요**
- 실수를 지적받았을 때 **방어적이 되지 않는다**

---

## 효과적인 코드 리뷰를 위한 마인드셋
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것
- **사람은 누구나 실수한다**: 리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요
- **칭찬도 좋은 코드 리뷰이다**: 특별히 남길 의견이 없다면 칭찬을 해보자

### 리뷰를 위한 리뷰 자제
- 리뷰를 위한 리뷰는 자제하자. 리뷰를 위한 리뷰는 지적을 초래한다

---
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 리프레시 토큰 도입 및 토큰 재발급 API 추가. 로그인/회원가입 시 액세스 토큰은 헤더, 리프레시 토큰은 본문으로 제공.
  - 회원 탈퇴 API 추가(액세스/리프레시 토큰 검증 기반).
- Bug Fixes
  - 액세스 토큰 만료 시 403 응답으로 일관 처리 및 안내 메시지 개선.
- Documentation
  - 로그인/회원가입/재발급/댓글·게시글·도서 등의 엔드포인트에 403 만료 사례와 예시 추가.
- Chores
  - 리프레시 토큰 저장용 스키마 및 설정 추가(만료 시간 구성).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->