### PR TITLE
#613 리프레시 토큰 저장 전 중복 체크 로직 추가

### DIFF
--- a/backend/src/main/java/todoktodok/backend/global/jwt/TokenInfo.java
+++ b/backend/src/main/java/todoktodok/backend/global/jwt/TokenInfo.java
@@ -4,7 +4,7 @@ import todoktodok.backend.global.auth.Role;
 
 public record TokenInfo(
         Long id,
-        String tempUserEmail,
+        String email,
         Role role
 ) {
 }

--- a/backend/src/main/java/todoktodok/backend/global/resolver/TempMemberArgumentResolver.java
+++ b/backend/src/main/java/todoktodok/backend/global/resolver/TempMemberArgumentResolver.java
@@ -37,11 +37,11 @@ public class TempMemberArgumentResolver implements HandlerMethodArgumentResolver
         final String token = getTokenFromAuthorizationHeader(httpServletRequest);
         final TokenInfo tokenInfo = jwtTokenProvider.getInfoByAccessToken(token);
 
-        if (tokenInfo.tempUserEmail() == null) {
+        if (tokenInfo.email() == null) {
             log.warn("JWT 토큰에서 이메일 정보를 확인할 수 없습니다");
             throw new JwtException("잘못된 로그인 시도입니다. 다시 시도해주세요.");
         }
-        return tokenInfo.tempUserEmail();
+        return tokenInfo.email();
     }
 
     private String getTokenFromAuthorizationHeader(final HttpServletRequest httpServletRequest) {

--- a/backend/src/main/java/todoktodok/backend/member/domain/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/todoktodok/backend/member/domain/repository/RefreshTokenRepository.java
@@ -7,4 +7,6 @@ import todoktodok.backend.member.domain.RefreshToken;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByToken(final String token);
+
+    boolean existsByToken(final String refreshToken);
 }

--- a/backend/src/test/java/todoktodok/backend/member/application/service/command/MemberCommandServiceConcurrencyTest.java
+++ b/backend/src/test/java/todoktodok/backend/member/application/service/command/MemberCommandServiceConcurrencyTest.java
@@ -1,0 +1,98 @@
+package todoktodok.backend.member.application.service.command;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import todoktodok.backend.InitializerTimer;
+import todoktodok.backend.global.auth.Role;
+import todoktodok.backend.global.jwt.JwtTokenProvider;
+import todoktodok.backend.global.jwt.TokenInfo;
+import todoktodok.backend.member.application.dto.request.RefreshTokenRequest;
+import todoktodok.backend.member.domain.Member;
+import todoktodok.backend.member.domain.RefreshToken;
+import todoktodok.backend.member.domain.repository.RefreshTokenRepository;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("local")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ContextConfiguration(initializers = InitializerTimer.class)
+class MemberCommandServiceConcurrencyTest {
+
+    @Autowired
+    MemberCommandService memberCommandService;
+
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("리프레시 토큰 발급 요청을 중복으로 보낼 때, 중복된 토큰 생성 시 예외를 발생한다")
+    void refresh_validateDuplicatedToken() throws Exception {
+        // given
+        final String oldRefresh = "old-token";
+        final String newFixed = "new-fixed-token";
+        final long memberId = 1L;
+
+        // 기존 토큰/회원 식별 가능하도록 JwtTokenProvider 동작 고정
+        Mockito.when(jwtTokenProvider.getInfoByRefreshToken(oldRefresh))
+                .thenReturn(new TokenInfo(memberId, "user@gmail.com", Role.USER));
+        Mockito.when(jwtTokenProvider.createAccessToken(Mockito.any(Member.class)))
+                .thenReturn("any-access");
+        Mockito.when(jwtTokenProvider.createRefreshToken(Mockito.any(Member.class)))
+                .thenReturn(newFixed); // 두 스레드 모두 같은 새 토큰 생성
+
+        // 기존 oldRefresh 엔트리 미리 넣어두기(상황에 맞게)
+        refreshTokenRepository.save(RefreshToken.create(oldRefresh));
+
+        // 동시 시작 장치
+        final int threads = 2;
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+
+        final List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+
+        final Runnable task = () -> {
+            ready.countDown();
+            try {
+                start.await();
+                memberCommandService.refresh(new RefreshTokenRequest(oldRefresh));
+            } catch (Throwable t) {
+                errors.add(t);
+            } finally {
+                done.countDown();
+            }
+        };
+
+        new Thread(task, "t1").start();
+        new Thread(task, "t2").start();
+
+        // when: 두 스레드가 준비될 때까지 대기 후 동시에 시작
+        ready.await();
+        start.countDown();
+        done.await();
+
+        // then: 하나는 성공, 하나는 UNIQUE 위반 예외
+        final boolean saved = refreshTokenRepository.findByToken(newFixed).isPresent();
+        assertThat(saved).isTrue();
+
+        // 예외 검증(구체 예외는 DB/Hibernate에 따라 상이)
+        final boolean hasUniqueViolation = errors.stream().anyMatch(e ->
+                e instanceof org.springframework.dao.DataIntegrityViolationException
+                        || e.getCause() instanceof org.hibernate.exception.ConstraintViolationException);
+        assertThat(hasUniqueViolation).isFalse();
+    }
+}

--- a/backend/src/test/java/todoktodok/backend/member/application/service/command/MemberCommandServiceTest.java
+++ b/backend/src/test/java/todoktodok/backend/member/application/service/command/MemberCommandServiceTest.java
@@ -29,9 +29,7 @@ import todoktodok.backend.member.application.dto.request.RefreshTokenRequest;
 import todoktodok.backend.member.application.dto.request.SignupRequest;
 import todoktodok.backend.member.application.dto.response.ProfileUpdateResponse;
 import todoktodok.backend.member.application.dto.response.TokenResponse;
-import todoktodok.backend.member.domain.Member;
 import todoktodok.backend.member.domain.repository.RefreshTokenRepository;
-import todoktodok.backend.member.presentation.fixture.MemberFixture;
 
 @ActiveProfiles("test")
 @Transactional


### PR DESCRIPTION
## 작업 내용 요약

<!-- 주요 개발 작업 내용을 간단히 서술해주세요 -->
<!-- 공동 작업이라면, 각자의 담당 영역을 함께 표기해주세요 -->

- close #613 
- 문제 상황) 한 화면를 만드려면 여러 요청을 동시에 보냅니다. 이때 액세스토큰이 만료되면 안드로이드는 만료 응답을 가로채 토큰 재발급 요청(/refresh)를 보내고, DataIntegrityViolationException이 발생합니다. 
  - 이유 : /refresh 요청이 한 화면에서 여러번 가면, 서버는 동시에 같은 사용자에 대해서 /refresh를 몇번씩 수행합니다. 그러다보니 토큰이 중복으로 생겼고, unique인 토큰 컬럼에 insert할 때 DataIntegrity 에러가 발생하고 있다고 예상 중입니다.
  
- 해결) 안드에서 /refresh 요청을 중복으로 보내는 오류는 해결 중이지만, 서버는 서버대로 리프레시 토큰이 중복으로 만들어졌을 때 400 에러를 발생시킵니다. 

- 중복을 판단하는 법)
  1.  RefreshTokenRepository에서 새로 발급한 토큰을 가지고 동일한 값의 토큰이 있는지 확인하고, 있으면 예외가 발생합니다.
  2. 동시성 문제로 인해 1의 방법은 항상 안전하지 않습니다. 1에서 에러가 발생하지 않아서 실제로 save하더라도 DataIntegrityViolationException이 발생하면 이를 받아서 예외를 발생시킵니다.
 
- 어제 학습한 스레드 퀘스트를 활용해 동시성 테스트를 추가해보았습니다. (MemberCommandServiceConcurrencyTest)
  - 이때 원래 테스트는 Jpa 엔티티를 기반으로 스키마를 만드는데, Jpa 엔티티에는 토큰 unique 제약조건이 없어서 테스트 환경이 완전하지 않습니다. 그래서 @ActiveProfiles는 local을 활성화해서 schema.sql을 기반으로 스키마를 생성했어요!
  - GPT햄과 짰는데, 혹시 이부분은 이상하다~ 싶은 거 있으면 제안해주세요!
---

## 리뷰/머지 희망 기한 (선택)

<!-- 해당 PR이 언제까지 리뷰되길 바라는지 작성해주세요 -->

- 6시 전에 해서 페토상 테스트할 수 있게 해주세욤!

---

<!-- 안드로이드 전용 추가 템플릿
## 셀프 체크리스트
- [ ] 프로그램이 정상적으로 작동하는가?
- [ ] 모든 테스트가 통과하는가?
- [ ] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [ ] 코딩 스타일 가이드를 준수하였는가?
- [ ] IDE 코드 자동 정렬을 적용하였는가?
- [ ] 린트 검사를 통과하였는가?

## 스크린샷

---

## 테스트 방법

---

-->


## 셀프 체크리스트
- [x] 프로그램이 정상적으로 작동하는가?
- [x] 모든 테스트가 통과하는가?
- [x] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [x] 코딩 스타일 가이드를 준수하였는가?
- [x] IDE 코드 자동 정렬을 적용하였는가?


## 리뷰어 셀프 체크리스트

> 리뷰 시 복사해서 사용해주세요!

```
- [ ]  리뷰어의 로컬에서 정상적으로 동작함을 확인했나요?
- [ ]  필요한 테스트가 모두 작성되어있음을 확인했나요?
- [ ]  테스트가 모두 통과함을 확인했나요?
- [ ]  성공, 경계값, 예외 등 가능한 시나리오를 모두 확인했나요?
- [ ]  리뷰 시 Pn 룰을 적용했나요?
```

</details>

<br/>
<details>
<summary> ⛳️ Pn 그라운드 룰 </summary>
<br>
  
### P1: 꼭 반영해주세요 (Request changes)
리뷰어는 PR의 내용이 서비스에 중대한 오류를 발생할 수 있는 가능성을 잠재하고 있는 등 중대한 코드 수정이 반드시 필요하다고 판단되는 경우, P1 태그를 통해 리뷰 요청자에게 수정을 요청합니다. 리뷰 요청자는 p1 태그에 대해 리뷰어의 요청을 반영하거나, 반영할 수 없는 합리적인 의견을 통해 리뷰어를 설득할 수 있어야 합니다.

### P2: 적극적으로 고려해주세요 (Request changes)
작성자는 P2에 대해 수용하거나 만약 수용할 수 없는 상황이라면 적합한 의견을 들어 토론할 것을 권장합니다.

### P3: 웬만하면 반영해 주세요 (Comment)
작성자는 P3에 대해 수용하거나 만약 수용할 수 없는 상황이라면 반영할 수 없는 이유를 들어 설명하거나 다음에 반영할 계획을 명시적으로(JIRA 티켓 등으로) 표현할 것을 권장합니다. Request changes 가 아닌 Comment 와 함께 사용됩니다.

### P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
작성자는 P4에 대해서는 아무런 의견을 달지 않고 무시해도 괜찮습니다. 해당 의견을 반영하는 게 좋을지 고민해 보는 정도면 충분합니다.

### P5: 그냥 사소한 의견입니다 (Approve)
작성자는 P5에 대해 아무런 의견을 달지 않고 무시해도 괜찮습니다.

</details>


<br/>
<details>
<summary> 📖 효과적인 코드 리뷰를 위한 제안 </summary>

## 1. 작업 목표 설정

### 목표 명확화
- 이슈 티켓 발행 시 이슈의 목표를 명확히 설정한다
- 큰 작업은 여러 개의 작은 티켓으로 분할하여 진행한다
- **PR은 최대 500 Line 제한**
- 주요 변경사항이나 새로운 패턴 도입 시 **반드시 사전에 논의**한다

## 2. 마감 기한 설정
- 리뷰 및 반영 기간이 길어질수록 PR의 크기는 커진다
- 리뷰에 대한 부담을 줄이기 위해 **피드백 마감기한을 팀과 설정**
  - **리뷰 완료 기준 24시간 이내**

## 3. 리뷰어의 자세와 원칙

### 3.1 기본 원칙
- 피드백은 **코드, 프로세스, 사양만**을 대상으로 한다
- 리뷰이와 리뷰어의 인격과는 **분리**되어야 한다
- 언어 폭력이나 비난이 섞인 지적은 리뷰가 아니다
- **시간에 쫓겨 리뷰의 품질을 낮추지 말자**

### 3.2 리뷰어의 자세
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것. 새로 감정이 상하지 않도록 노력이 필요
- **적절한 시간 분배**: 리뷰어가 감당할 수 있는 양의 리뷰를 나누고, 피드백 마감기한을 지키자
- **우선순위를 정해 피드백이 필요한 부분만 간단히 리뷰를 주고받는다**

### 3.3 리뷰 의견 제시 방법

#### 건설적 피드백
- **긍정적 표현 사용**
  - ❌ "이 코드는 잘못되었다"
  - ✅ "이 부분을 다음과 같이 개선할 수 있을 것 같습니다"

#### 구체적인 제안
- ❌ "성능이 안 좋다"
- ✅ "A 방법 대신 B를 사용하면 가독성이 향상될 것 같습니다"

#### 리뷰는 토론과 같다
- 토론을 하되, 리뷰를 넘길 때도 의견과 함께 리뷰어가 납득할 수 있는 이유와 근거(자료 등)를 충분히 제시

### 3.4 적절한 시간 분배
- 리뷰를 위한 리뷰는 리뷰 품질의 저하을 초래한다. 피드백 할 부분이 없다면 **칭찬을 남기자**
- 사람은 누구나 실수한다
- **리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요**
- 실수를 지적받았을 때 **방어적이 되지 않는다**

---

## 효과적인 코드 리뷰를 위한 마인드셋
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것
- **사람은 누구나 실수한다**: 리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요
- **칭찬도 좋은 코드 리뷰이다**: 특별히 남길 의견이 없다면 칭찬을 해보자

### 리뷰를 위한 리뷰 자제
- 리뷰를 위한 리뷰는 자제하자. 리뷰를 위한 리뷰는 지적을 초래한다

---
</details>
