### PR TITLE
#930 토론방, 댓글, 대댓글 조회 API의 N+1 쿼리 제거

### DIFF
--- a/backend/src/main/java/todoktodok/backend/comment/application/service/query/CommentQueryService.java
+++ b/backend/src/main/java/todoktodok/backend/comment/application/service/query/CommentQueryService.java
@@ -83,7 +83,7 @@ public class CommentQueryService {
     }
 
     private Comment findComment(final Long commentId) {
-        return commentRepository.findById(commentId)
+        return commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new NoSuchElementException(String.format("해당 댓글을 찾을 수 없습니다: commentId = %s", commentId)));
     }
 

--- a/backend/src/main/java/todoktodok/backend/comment/domain/Comment.java
+++ b/backend/src/main/java/todoktodok/backend/comment/domain/Comment.java
@@ -1,13 +1,6 @@
 package todoktodok.backend.comment.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/backend/src/main/java/todoktodok/backend/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/todoktodok/backend/comment/domain/repository/CommentRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,9 +14,18 @@ import todoktodok.backend.discussion.domain.Discussion;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    boolean existsCommentsByDiscussion(final Discussion discussion);
+
+    @EntityGraph(attributePaths = {"member"})
     List<Comment> findCommentsByDiscussion(final Discussion discussion);
 
-    boolean existsCommentsByDiscussion(final Discussion discussion);
+    @EntityGraph(attributePaths = {"member"})
+    @Query("""
+                SELECT c
+                FROM Comment c
+                WHERE c.id = :commentId
+            """)
+    Optional<Comment> findByIdWithMember(@Param("commentId") final Long commentId);
 
     @Query("""
                 SELECT new todoktodok.backend.discussion.application.service.query.DiscussionCommentCountDto(
@@ -63,18 +73,18 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     );
 
     @Query("""
-        SELECT COUNT(c)
-        FROM Comment c
-        WHERE c.discussion.id = :discussionId
-    """)
+                SELECT COUNT(c)
+                FROM Comment c
+                WHERE c.discussion.id = :discussionId
+            """)
     Long countCommentsByDiscussionId(@Param("discussionId") final Long discussionId);
 
     @Query("""
-    SELECT MAX(c.id)
-    FROM Comment c
-    WHERE c.discussion = :discussion
-    AND c.createdAt >= :periodStart
-""")
+                SELECT MAX(c.id)
+                FROM Comment c
+                WHERE c.discussion = :discussion
+                AND c.createdAt >= :periodStart
+            """)
     Optional<Long> findLatestCommentIdByDiscussion(
             @Param("discussion") Discussion discussion,
             @Param("periodStart") LocalDateTime periodStart

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/command/DiscussionCommandService.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/command/DiscussionCommandService.java
@@ -5,6 +5,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -97,7 +98,6 @@ public class DiscussionCommandService {
         discussion.update(discussionTitle, discussionOpinion);
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateDiscussionMemberView(
             final Long memberId,
             final Long discussionId
@@ -108,20 +108,43 @@ public class DiscussionCommandService {
         final Optional<DiscussionMemberView> discussionMemberView
                 = discussionMemberViewRepository.findByMemberAndDiscussion(member, discussion);
 
-        if (discussionMemberView.isEmpty()) {
+        if (discussionMemberView.isPresent()) {
+            updateMemberViewIfAfter10Minutes(discussionMemberView.get(), discussionId);
+            return;
+        }
+
+        insertMemberView(member, discussion);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void insertMemberView(final Member member, final Discussion discussion) {
+        try {
             final DiscussionMemberView view = DiscussionMemberView.builder()
                     .discussion(discussion)
                     .member(member)
                     .build();
-            discussionMemberViewRepository.save(view);
-            discussionRepository.increaseViewCount(discussionId);
-            return;
-        }
 
-        if (discussionMemberView.get().isModifiedDatePassedFrom(VIEW_THRESHOLD)) {
-            discussionMemberViewRepository.updateModifiedAtById(discussionMemberView.get().getId(), LocalDateTime.now());
-            discussionRepository.increaseViewCount(discussionId);
+            discussionMemberViewRepository.save(view);
+            increaseViewCountSafely(discussion.getId());
+        } catch (final DataIntegrityViolationException e) {
+            // 비동기 로직에서 Race Condition 발생한 경우 다시 업데이트 처리
+            final DiscussionMemberView savedDiscussionMemberView = discussionMemberViewRepository.findByMemberAndDiscussion(member, discussion)
+                    .orElseThrow();
+            updateMemberViewIfAfter10Minutes(savedDiscussionMemberView, discussion.getId());
         }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateMemberViewIfAfter10Minutes(final DiscussionMemberView discussionMemberView, final Long discussionId) {
+        if (discussionMemberView.isModifiedDatePassedFrom(VIEW_THRESHOLD)) {
+            discussionMemberViewRepository.updateModifiedAtById(discussionMemberView.getId(), LocalDateTime.now());
+            increaseViewCountSafely(discussionId);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void increaseViewCountSafely(final Long discussionId) {
+        discussionRepository.increaseViewCount(discussionId);
     }
 
     public void deleteDiscussion(

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/event/DiscussionEventHandler.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/event/DiscussionEventHandler.java
@@ -81,7 +81,12 @@ public class DiscussionEventHandler {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleDiscussionView(final DiscussionViewEvent discussionViewEvent) {
-        log.info("DiscussionViewEvent 실행");
-        discussionCommandService.updateDiscussionMemberView(discussionViewEvent.memberId(), discussionViewEvent.discussionId());
+        try {
+            log.info("DiscussionViewEvent 실행");
+            discussionCommandService.updateDiscussionMemberView(discussionViewEvent.memberId(),
+                    discussionViewEvent.discussionId());
+        } catch (final Exception e) {
+            log.error("비동기 처리 중 오류 발생, cause: {}", e.getMessage(), e);
+        }
     }
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryService.java
@@ -116,23 +116,9 @@ public class DiscussionQueryService {
 
         final Member member = findMember(memberId);
         final LocalDateTime sinceDate = LocalDate.now().minusDays(period).atStartOfDay();
-        final List<Long> discussionIds = discussionRepository.findAllIds();
+        final Pageable pageable = PageRequest.of(0, count);
 
-        if (discussionIds.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        final List<DiscussionLikeSummaryDto> likeSinceCounts = discussionLikeRepository.findLikeSummariesByDiscussionIdsSinceDate(
-                member, discussionIds, sinceDate);
-        final List<DiscussionCommentCountDto> commentSinceCounts = commentRepository.findCommentCountsByDiscussionIdsSinceDate(
-                discussionIds, sinceDate);
-
-        final Map<Long, LikeCountAndIsLikedByMeDto> likesByDiscussionId = mapLikeSummariesByDiscussionId(
-                likeSinceCounts);
-        final Map<Long, Integer> commentsByDiscussionId = mapTotalCommentCountsByDiscussionId(commentSinceCounts);
-
-        final List<Long> hotDiscussionIds = findHotDiscussions(count, likesByDiscussionId, commentsByDiscussionId,
-                discussionIds);
+        final List<Long> hotDiscussionIds = discussionRepository.findHotDiscussionIds(sinceDate, pageable);
 
         return getDiscussionsResponses(hotDiscussionIds, member);
     }
@@ -202,7 +188,7 @@ public class DiscussionQueryService {
     }
 
     private Discussion findDiscussion(final Long discussionId) {
-        return discussionRepository.findById(discussionId)
+        return discussionRepository.findByIdWithMemberAndBook(discussionId)
                 .orElseThrow(() -> new NoSuchElementException(
                                 String.format("해당 토론방을 찾을 수 없습니다: discussionId= %s", discussionId)
                         )

--- a/backend/src/main/java/todoktodok/backend/discussion/domain/Discussion.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/domain/Discussion.java
@@ -1,13 +1,7 @@
 package todoktodok.backend.discussion.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -25,6 +19,14 @@ import todoktodok.backend.member.domain.Member;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+
+@NamedEntityGraph(
+        name = "Discussion.withMemberAndBook",
+        attributeNodes = {
+                @NamedAttributeNode("member"),
+                @NamedAttributeNode("book")
+        }
+)
 
 @Entity
 @DynamicInsert

--- a/backend/src/main/java/todoktodok/backend/discussion/domain/repository/DiscussionRepository.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/domain/repository/DiscussionRepository.java
@@ -16,6 +16,15 @@ import todoktodok.backend.member.domain.Member;
 
 public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
 
+    @EntityGraph(value = "Discussion.withMemberAndBook", type = EntityGraph.EntityGraphType.LOAD)
+    @Query("""
+                   SELECT d
+                   FROM Discussion d
+                   WHERE d.id = :discussionId
+            """)
+    Optional<Discussion> findByIdWithMemberAndBook(final Long discussionId);
+
+    @EntityGraph(value = "Discussion.withMemberAndBook", type = EntityGraph.EntityGraphType.LOAD)
     @Query("""
                    SELECT d
                    FROM Discussion d

--- a/backend/src/main/java/todoktodok/backend/discussion/domain/repository/DiscussionRepository.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/domain/repository/DiscussionRepository.java
@@ -2,8 +2,11 @@ package todoktodok.backend.discussion.domain.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -141,4 +144,37 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
                 WHERE d.id = :discussionId
             """)
     void increaseViewCount(@Param("discussionId") final Long discussionId);
+
+    @Query(
+            value = """
+            SELECT
+                activity.discussion_id
+            FROM (
+                SELECT dl.discussion_id
+                FROM discussion_like dl
+                WHERE dl.created_at >= :sinceDate AND dl.deleted_at IS NULL
+
+                UNION ALL
+                SELECT c.discussion_id
+                FROM comment c
+                WHERE c.created_at >= :sinceDate AND c.deleted_at IS NULL
+
+                UNION ALL
+                SELECT c.discussion_id
+                FROM reply r
+                JOIN comment c ON r.comment_id = c.id
+                WHERE r.created_at >= :sinceDate AND r.deleted_at IS NULL AND c.deleted_at IS NULL
+            ) AS activity
+            GROUP BY
+                activity.discussion_id
+            ORDER BY
+                COUNT(activity.discussion_id) DESC, activity.discussion_id DESC
+            """,
+            nativeQuery = true
+    )
+    List<Long> findHotDiscussionIds(
+            @Param("sinceDate") final LocalDateTime sinceDate,
+            final Pageable pageable
+    );
+
 }

--- a/backend/src/main/java/todoktodok/backend/discussion/domain/repository/DiscussionRepository.java
+++ b/backend/src/main/java/todoktodok/backend/discussion/domain/repository/DiscussionRepository.java
@@ -22,7 +22,7 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
                    FROM Discussion d
                    WHERE d.id = :discussionId
             """)
-    Optional<Discussion> findByIdWithMemberAndBook(final Long discussionId);
+    Optional<Discussion> findByIdWithMemberAndBook(@Param("discussionId") final Long discussionId);
 
     @EntityGraph(value = "Discussion.withMemberAndBook", type = EntityGraph.EntityGraphType.LOAD)
     @Query("""
@@ -174,6 +174,8 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
                 JOIN comment c ON r.comment_id = c.id
                 WHERE r.created_at >= :sinceDate AND r.deleted_at IS NULL AND c.deleted_at IS NULL
             ) AS activity
+            JOIN discussion d ON d.id = activity.discussion_id
+            WHERE d.deleted_at IS NULL
             GROUP BY
                 activity.discussion_id
             ORDER BY

--- a/backend/src/main/java/todoktodok/backend/reply/domain/repository/ReplyRepository.java
+++ b/backend/src/main/java/todoktodok/backend/reply/domain/repository/ReplyRepository.java
@@ -1,6 +1,8 @@
 package todoktodok.backend.reply.domain.repository;
 
 import java.util.List;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +14,9 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
     int countRepliesByComment(final Comment comment);
 
+    @EntityGraph(attributePaths = {"member"})
+    List<Reply> findRepliesByComment(final Comment comment);
+
     @Query("""
                 SELECT new todoktodok.backend.comment.application.service.query.CommentReplyCountDto(c.id, COUNT(r))
                 FROM Comment c
@@ -20,8 +25,6 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
                 GROUP BY c.id
             """)
     List<CommentReplyCountDto> findReplyCountsByCommentIds(@Param("commentIds") final List<Long> commentIds);
-
-    List<Reply> findRepliesByComment(final Comment comment);
 
     boolean existsByComment(final Comment comment);
 }

--- a/backend/src/main/resources/db/local/schema.sql
+++ b/backend/src/main/resources/db/local/schema.sql
@@ -213,5 +213,6 @@ CREATE TABLE discussion_member_view
     discussion_id     BIGINT NOT NULL,
     member_id         BIGINT NOT NULL,
     FOREIGN KEY (discussion_id) REFERENCES discussion (id),
-    FOREIGN KEY (member_id) REFERENCES member (id)
+    FOREIGN KEY (member_id) REFERENCES member (id),
+    UNIQUE (discussion_id, member_id)
 );

--- a/backend/src/main/resources/db/migration/V10__alter_discussion_member_view_unique.sql
+++ b/backend/src/main/resources/db/migration/V10__alter_discussion_member_view_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE discussion_member_view
+ADD CONSTRAINT uq_discussion_member UNIQUE (discussion_id, member_id);

--- a/backend/src/main/resources/db/migration_dev/V12__alter_discussion_member_view_unique.sql
+++ b/backend/src/main/resources/db/migration_dev/V12__alter_discussion_member_view_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE discussion_member_view
+ADD CONSTRAINT uq_discussion_member UNIQUE (discussion_id, member_id);

--- a/backend/src/test/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryServiceTest.java
+++ b/backend/src/test/java/todoktodok/backend/discussion/application/service/query/DiscussionQueryServiceTest.java
@@ -12,6 +12,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +25,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import todoktodok.backend.DatabaseInitializer;
@@ -43,9 +46,22 @@ class DiscussionQueryServiceTest {
     @Autowired
     private DiscussionQueryService discussionQueryService;
 
+    @Autowired
+    private ThreadPoolTaskExecutor taskExecutor;
+
     @BeforeEach
     void setUp() {
         databaseInitializer.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 비동기 테스트 떄문에 현재 큐에 남아있는 작업이나 활성 스레드가 없을 때까지 대기
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() ->
+                    taskExecutor.getThreadPoolExecutor().getActiveCount() == 0 &&
+                        taskExecutor.getThreadPoolExecutor().getQueue().isEmpty()
+        );
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용 요약

<!-- 주요 개발 작업 내용을 간단히 서술해주세요 -->
<!-- 공동 작업이라면, 각자의 담당 영역을 함께 표기해주세요 -->

- N+1 문제를 해결하여, 모든 토론방 조회에서 발생하는 추가 쿼리 (= 최대 `2 * (조회하는 토론방 개수)` 개)를 제거했습니다. 
- N+1 문제를 해결하여, 모든 댓글/대댓글 조회에서 발생하는 추가 쿼리 (= `조회하는 댓글/대댓글 개수`개)를 제거했습니다.
- 인기 토론방 조회 로직이 쿼리 개수가 너무 많고 (7개) 애플리케이션 로직의 부담도 큰 관계로, 쿼리 개수를 5개로 줄이고 인기 토론방 조회 쿼리를 개선했습니다.

## 구체적인 문제, 해결 과정, 결과
[문서](https://slash-bougon-ea8.notion.site/N-1-2cab2d6e3e6e80319924d23330652d7d) 로 아주 상세히 작성했습니다!

## 논의할 점!!

그동안 인기 토론방에서 치명적인 문제가 있었는데요, 모든 토론방에 대해서 좋아요+댓글수로 내림차순한 뒤에 필요한 개수만큼 잘라서 쓰기 때문에, 인기 토론방이 적은 경우에는 좋아요+댓글이 하나도 없는 토론방도 인기토론방에 포함될 수 있습니다.

> ex. 2025년 12월 6일 이후 작성된 좋아요+댓글수로 정렬했을 때, 좋아요+댓글수가 높은 순부터 {10개, 9개, 5개, 0개, 0개, 0개, ....} 이다 -> 상위 5개를 반환하게 되면 좋아요+댓글이 0개인 토론방도 인기 토론방으로 뽑히게 된다.

새로 수정한 쿼리에서는 이 문제점이 그대로 영향을 받아서, **<좋아요+댓글 수가 1개 이상인 토론방 개수가 미달일 때 어떻게 할지> 를 논의하고 싶습니다.**

ex. 남은 개수는 랜덤 토론방으로 채우기, 아니면 인기 조회 기간을 더 넓혀서 재탐색하기 등

---

## 리뷰/머지 희망 기한 (선택)

<!-- 해당 PR이 언제까지 리뷰되길 바라는지 작성해주세요 -->

- ㅎㅎ 편할때 봐주시고, 의견이 있다면 며칠이 지났건 남겨주세용

---

<!-- 안드로이드 전용 추가 템플릿
## 셀프 체크리스트
- [ ] 프로그램이 정상적으로 작동하는가?
- [ ] 모든 테스트가 통과하는가?
- [ ] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [ ] 코딩 스타일 가이드를 준수하였는가?
- [ ] IDE 코드 자동 정렬을 적용하였는가?
- [ ] 린트 검사를 통과하였는가?

## 스크린샷

---

## 테스트 방법

---

-->

<!-- 백엔드 전용 추가 템플릿

## 셀프 체크리스트
- [ ] 프로그램이 정상적으로 작동하는가?
- [ ] 모든 테스트가 통과하는가?
- [ ] 불필요한 주석 또는 디버깅을 위한 Log를 모두 제거하였는가?
- [ ] 코딩 스타일 가이드를 준수하였는가?
- [ ] IDE 코드 자동 정렬을 적용하였는가?

-->

## 리뷰어 셀프 체크리스트

> 리뷰 시 복사해서 사용해주세요!

```
- [ ]  리뷰어의 로컬에서 정상적으로 동작함을 확인했나요?
- [ ]  필요한 테스트가 모두 작성되어있음을 확인했나요?
- [ ]  테스트가 모두 통과함을 확인했나요?
- [ ]  성공, 경계값, 예외 등 가능한 시나리오를 모두 확인했나요?
- [ ]  리뷰 시 Pn 룰을 적용했나요?
```

</details>

<br/>
<details>
<summary> ⛳️ Pn 그라운드 룰 </summary>
<br>
  
### P1: 꼭 반영해주세요 (Request changes)
리뷰어는 PR의 내용이 서비스에 중대한 오류를 발생할 수 있는 가능성을 잠재하고 있는 등 중대한 코드 수정이 반드시 필요하다고 판단되는 경우, P1 태그를 통해 리뷰 요청자에게 수정을 요청합니다. 리뷰 요청자는 p1 태그에 대해 리뷰어의 요청을 반영하거나, 반영할 수 없는 합리적인 의견을 통해 리뷰어를 설득할 수 있어야 합니다.

### P2: 적극적으로 고려해주세요 (Request changes)
작성자는 P2에 대해 수용하거나 만약 수용할 수 없는 상황이라면 적합한 의견을 들어 토론할 것을 권장합니다.

### P3: 웬만하면 반영해 주세요 (Comment)
작성자는 P3에 대해 수용하거나 만약 수용할 수 없는 상황이라면 반영할 수 없는 이유를 들어 설명하거나 다음에 반영할 계획을 명시적으로(JIRA 티켓 등으로) 표현할 것을 권장합니다. Request changes 가 아닌 Comment 와 함께 사용됩니다.

### P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
작성자는 P4에 대해서는 아무런 의견을 달지 않고 무시해도 괜찮습니다. 해당 의견을 반영하는 게 좋을지 고민해 보는 정도면 충분합니다.

### P5: 그냥 사소한 의견입니다 (Approve)
작성자는 P5에 대해 아무런 의견을 달지 않고 무시해도 괜찮습니다.

</details>


<br/>
<details>
<summary> 📖 효과적인 코드 리뷰를 위한 제안 </summary>

## 1. 작업 목표 설정

### 목표 명확화
- 이슈 티켓 발행 시 이슈의 목표를 명확히 설정한다
- 큰 작업은 여러 개의 작은 티켓으로 분할하여 진행한다
- **PR은 최대 500 Line 제한**
- 주요 변경사항이나 새로운 패턴 도입 시 **반드시 사전에 논의**한다

## 2. 마감 기한 설정
- 리뷰 및 반영 기간이 길어질수록 PR의 크기는 커진다
- 리뷰에 대한 부담을 줄이기 위해 **피드백 마감기한을 팀과 설정**
  - **리뷰 완료 기준 24시간 이내**

## 3. 리뷰어의 자세와 원칙

### 3.1 기본 원칙
- 피드백은 **코드, 프로세스, 사양만**을 대상으로 한다
- 리뷰이와 리뷰어의 인격과는 **분리**되어야 한다
- 언어 폭력이나 비난이 섞인 지적은 리뷰가 아니다
- **시간에 쫓겨 리뷰의 품질을 낮추지 말자**

### 3.2 리뷰어의 자세
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것. 새로 감정이 상하지 않도록 노력이 필요
- **적절한 시간 분배**: 리뷰어가 감당할 수 있는 양의 리뷰를 나누고, 피드백 마감기한을 지키자
- **우선순위를 정해 피드백이 필요한 부분만 간단히 리뷰를 주고받는다**

### 3.3 리뷰 의견 제시 방법

#### 건설적 피드백
- **긍정적 표현 사용**
  - ❌ "이 코드는 잘못되었다"
  - ✅ "이 부분을 다음과 같이 개선할 수 있을 것 같습니다"

#### 구체적인 제안
- ❌ "성능이 안 좋다"
- ✅ "A 방법 대신 B를 사용하면 가독성이 향상될 것 같습니다"

#### 리뷰는 토론과 같다
- 토론을 하되, 리뷰를 넘길 때도 의견과 함께 리뷰어가 납득할 수 있는 이유와 근거(자료 등)를 충분히 제시

### 3.4 적절한 시간 분배
- 리뷰를 위한 리뷰는 리뷰 품질의 저하을 초래한다. 피드백 할 부분이 없다면 **칭찬을 남기자**
- 사람은 누구나 실수한다
- **리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요**
- 실수를 지적받았을 때 **방어적이 되지 않는다**

---

## 효과적인 코드 리뷰를 위한 마인드셋
- **리뷰는 모두를 위한 것이다**: 나 자신과 팀, 서비스를 위한 것
- **사람은 누구나 실수한다**: 리뷰어, 리뷰어 모두 실수를 빠르게 인정하고 열린 마음으로 토론하는 것이 중요
- **칭찬도 좋은 코드 리뷰이다**: 특별히 남길 의견이 없다면 칭찬을 해보자

### 리뷰를 위한 리뷰 자제
- 리뷰를 위한 리뷰는 자제하자. 리뷰를 위한 리뷰는 지적을 초래한다

---
</details>
